### PR TITLE
fix: fetch history on button click and not on web page load

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -50,44 +50,40 @@ export const fetchChatHistoryInit = (): Conversation[] | null => {
 }
 
 export const historyList = async (offset = 0): Promise<Conversation[] | null> => {
-  const response = await fetch(`/history/list?offset=${offset}`, {
-    method: 'GET'
-  })
-    .then(async res => {
-      const payload = await res.json()
-      if (!Array.isArray(payload)) {
-        console.error('There was an issue fetching your data.')
-        return null
-      }
-      const conversations: Conversation[] = await Promise.all(
-        payload.map(async (conv: any) => {
-          let convMessages: ChatMessage[] = []
-          convMessages = await historyRead(conv.id)
-            .then(res => {
-              return res
-            })
-            .catch(err => {
-              console.error('error fetching messages: ', err)
-              return []
-            })
-          const conversation: Conversation = {
-            id: conv.id,
-            title: conv.title,
-            date: conv.createdAt,
-            messages: convMessages
-          }
-          return conversation
-        })
-      )
-      return conversations
-    })
-    .catch(_err => {
-      console.error('There was an issue fetching your data.')
-      return null
-    })
+  try {
+    const res = await fetch(`/history/list?offset=${offset}`, { method: 'GET' });
+    const payload = await res.json();
 
-  return response
-}
+    if (!Array.isArray(payload)) {
+      console.error('There was an issue fetching your data.');
+      return null;
+    }
+
+    const conversations: Conversation[] = await Promise.all(
+      payload.map(async (conv: any) => {
+        let convMessages: ChatMessage[] = [];
+        
+        // try {
+        //   convMessages = await historyRead(conv.id);
+        // } catch (err) {
+        //   console.error('Error fetching messages:', err);
+        // }
+
+        return {
+          id: conv.id,
+          title: conv.title,
+          date: conv.createdAt,
+          messages: convMessages,
+        };
+      })
+    );
+
+    return conversations;
+  } catch (err) {
+    console.error('There was an issue fetching your data.', err);
+    return null;
+  }
+};
 
 export const historyRead = async (convId: string): Promise<ChatMessage[]> => {
   const response = await fetch('/history/read', {

--- a/frontend/src/components/ChatHistory/ChatHistoryList.test.tsx
+++ b/frontend/src/components/ChatHistory/ChatHistoryList.test.tsx
@@ -26,7 +26,8 @@ const mockState = {
   isGenerating: false,
   isRequestInitiated: false,
   failedSections : [],
-  isFailedReqInitiated : false
+  isFailedReqInitiated : false,
+  isLoading : false,
 };
 
 const renderChatHistoryList = (stateOverride = {}) => {

--- a/frontend/src/components/ChatHistory/ChatHistoryPanel.test.tsx
+++ b/frontend/src/components/ChatHistory/ChatHistoryPanel.test.tsx
@@ -53,7 +53,8 @@ const mockState = {
   isGenerating: false,
   isRequestInitiated: false,
   failedSections : [],
-  isFailedReqInitiated : false
+  isFailedReqInitiated : false,
+  isLoading : false,
 };
  
 const mockDispatch = jest.fn();

--- a/frontend/src/components/ChatHistory/ChatHistoryPanel.tsx
+++ b/frontend/src/components/ChatHistory/ChatHistoryPanel.tsx
@@ -73,7 +73,7 @@ export function ChatHistoryPanel(_props: ChatHistoryPanelProps) {
   const handleHistoryClick = () => {
     appStateContext?.dispatch({ type: 'TOGGLE_CHAT_HISTORY' })
   }
- 
+
   const onShowContextualMenu = React.useCallback((ev: React.MouseEvent<HTMLElement>) => {
     ev.preventDefault() // don't navigate
     setShowContextualMenu(true)

--- a/frontend/src/components/DraftCards/SectionCard.test.tsx
+++ b/frontend/src/components/DraftCards/SectionCard.test.tsx
@@ -55,7 +55,8 @@ const mockState = {
   isGenerating: false,
   isRequestInitiated: false,
   failedSections : [],
-  isFailedReqInitiated : false
+  isFailedReqInitiated : false,
+  isLoading : false,
 }
 
 const renderWithContext = (idx = 0) =>

--- a/frontend/src/components/Sidebar/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.test.tsx
@@ -53,7 +53,8 @@ const mockState = {
   isGenerating: false,
   isRequestInitiated: false,
   failedSections : [],
-  isFailedReqInitiated : false
+  isFailedReqInitiated : false,
+  isLoading : false,
 };
 const mockState2 = {
   isChatHistoryOpen: false,

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -10,7 +10,9 @@ import {
   IStackTokens,
   mergeStyleSets,
   IModalStyles,
-  PrimaryButton
+  PrimaryButton,
+  Spinner,
+  SpinnerSize
 } from '@fluentui/react'
 import { SquareRegular, ShieldLockRegular, ErrorCircleRegular } from '@fluentui/react-icons'
 
@@ -45,6 +47,7 @@ import { CitationPanel } from './Components/CitationPanel'
 import { AuthNotConfigure } from './Components/AuthNotConfigure'
 import { ChatMessageContainer } from './Components/ChatMessageContainer';
 import { parseErrorMessage, cleanJSON } from '../../helpers/helpers';
+
 
 const enum messageStatus {
   NotRunning = 'Not Running',
@@ -119,6 +122,11 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [modalUrl, setModalUrl] = useState('');
   const [finalMessages, setFinalMessages] = useState<ChatMessage[]>([])
+  if (!appStateContext || !appStateContext.state) {
+    console.error("AppStateContext is undefined. Ensure AppProvider wraps this component.");
+    return null; // Prevents execution if context is missing
+  }
+  const { currentChat } = appStateContext?.state;
 
   const errorDialogContentProps = {
     type: DialogType.close,
@@ -829,19 +837,23 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
       ) : (
         <Stack horizontal className={styles.chatRoot}>
           <div className={styles.chatContainer}>
-            {!messages || messages.length < 1 ? (
+            { appStateContext.state.isLoading ? (
+              <Stack horizontalAlign="center" verticalAlign="center" className={styles.chatLoadingState} style={{padding: 250, paddingBottom: 150}}>
+                <Spinner label="Loading your chat..." size={SpinnerSize.large} />
+              </Stack>
+            ): currentChat?.messages && currentChat.messages.length > 0 ? (
+              <ChatMessageContainer
+                messages={currentChat.messages}
+                isLoading={isLoading}
+                type={type}
+                onShowCitation={onShowCitation}
+                showLoadingMessage={showLoadingMessage}
+                ref={chatMessageStreamEnd}
+              />
+            ) : (
               <Stack className={styles.chatEmptyState}>
                 <h1 className={styles.chatEmptyStateTitle}>{ui?.chat_title}</h1>
               </Stack>
-            ) : (
-                <ChatMessageContainer
-                messages={messages}
-                  isLoading={isLoading}
-                  type={type}
-                  onShowCitation={onShowCitation}
-                  showLoadingMessage={showLoadingMessage}
-                  ref = {chatMessageStreamEnd}
-                />
             )}
 
             <Stack horizontal className={styles.chatInput}>

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -422,6 +422,9 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
     let conversation
     if (conversationId) {
       conversation = appStateContext?.state?.chatHistory?.find(conv => conv.id === conversationId)
+      if(!conversation){
+        conversation = appStateContext?.state?.currentChat
+      }
       if (!conversation) {
         console.error('Conversation not found.')
         setIsLoading(false)
@@ -460,6 +463,9 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
         let resultConversation
         if (conversationId) {
           resultConversation = appStateContext?.state?.chatHistory?.find(conv => conv.id === conversationId)
+          if(!resultConversation){
+            resultConversation = appStateContext?.state?.currentChat
+          }
           if (!resultConversation) {
             console.error('Conversation not found.')
             setIsLoading(false)
@@ -530,6 +536,9 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
         let resultConversation
         if (conversationId) {
           resultConversation = appStateContext?.state?.chatHistory?.find(conv => conv.id === conversationId)
+          if(!resultConversation){
+            resultConversation = appStateContext?.state?.currentChat
+          }
           if (!resultConversation) {
             console.error('Conversation not found.')
             setIsLoading(false)
@@ -585,6 +594,9 @@ const Chat = ({ type = ChatType.Browse }: Props) => {
         let resultConversation
         if (conversationId) {
           resultConversation = appStateContext?.state?.chatHistory?.find(conv => conv.id === conversationId)
+          if(!resultConversation){
+            resultConversation = appStateContext?.state?.currentChat
+          }
           if (!resultConversation) {
             console.error('Conversation not found.')
             setIsLoading(false)

--- a/frontend/src/state/AppProvider.tsx
+++ b/frontend/src/state/AppProvider.tsx
@@ -33,6 +33,7 @@ export interface AppState {
   isRequestInitiated : boolean,
   failedSections : Section[],
   isFailedReqInitiated : boolean,
+  isLoading: boolean,
 }
 
 export type Action =
@@ -64,6 +65,7 @@ export type Action =
   | { type: 'ADD_FAILED_SECTION'; payload: Section }
   | { type: 'REMOVED_FAILED_SECTION'; payload: {section : Section} }
   | { type: 'UPDATE_SECTION_API_REQ_STATUS'; payload: boolean }
+  | { type: 'SET_LOADING'; payload: boolean }
 
 const initialState: AppState = {
   isChatHistoryOpen: false,
@@ -84,7 +86,8 @@ const initialState: AppState = {
   isGenerating: false,
   isRequestInitiated: false,
   failedSections : [],
-  isFailedReqInitiated : false
+  isFailedReqInitiated : false,
+  isLoading: false,
 }
 
 export const AppStateContext = createContext<

--- a/frontend/src/state/AppProvider.tsx
+++ b/frontend/src/state/AppProvider.tsx
@@ -103,51 +103,13 @@ export const AppStateProvider: React.FC<AppStateProviderProps> = ({ children }) 
   const [state, dispatch] = useReducer(appStateReducer, initialState)
 
   useEffect(() => {
-    // Check for cosmosdb config and fetch initial data here
-    const fetchChatHistory = async (offset = 0): Promise<Conversation[] | null> => {
-      const result = await historyList(offset)
-        .then(response => {
-          if (response) {
-            dispatch({ type: 'FETCH_CHAT_HISTORY', payload: response })
-          } else {
-            dispatch({ type: 'FETCH_CHAT_HISTORY', payload: null })
-          }
-          return response
-        })
-        .catch(_err => {
-          dispatch({ type: 'UPDATE_CHAT_HISTORY_LOADING_STATE', payload: ChatHistoryLoadingState.Fail })
-          dispatch({ type: 'FETCH_CHAT_HISTORY', payload: null })
-          console.error('There was an issue fetching your data.')
-          return null
-        })
-      return result
-    }
-
     const getHistoryEnsure = async () => {
       dispatch({ type: 'UPDATE_CHAT_HISTORY_LOADING_STATE', payload: ChatHistoryLoadingState.Loading })
       historyEnsure()
         .then(response => {
           if (response?.cosmosDB) {
-            fetchChatHistory()
-              .then(res => {
-                if (res) {
-                  dispatch({ type: 'UPDATE_CHAT_HISTORY_LOADING_STATE', payload: ChatHistoryLoadingState.Success })
-                  dispatch({ type: 'SET_COSMOSDB_STATUS', payload: response })
-                } else {
-                  dispatch({ type: 'UPDATE_CHAT_HISTORY_LOADING_STATE', payload: ChatHistoryLoadingState.Fail })
-                  dispatch({
-                    type: 'SET_COSMOSDB_STATUS',
-                    payload: { cosmosDB: false, status: CosmosDBStatus.NotWorking }
-                  })
-                }
-              })
-              .catch(_err => {
-                dispatch({ type: 'UPDATE_CHAT_HISTORY_LOADING_STATE', payload: ChatHistoryLoadingState.Fail })
-                dispatch({
-                  type: 'SET_COSMOSDB_STATUS',
-                  payload: { cosmosDB: false, status: CosmosDBStatus.NotWorking }
-                })
-              })
+            dispatch({ type: 'SET_COSMOSDB_STATUS', payload: response })
+            dispatch({ type: 'UPDATE_CHAT_HISTORY_LOADING_STATE', payload: ChatHistoryLoadingState.Success })
           } else {
             dispatch({ type: 'UPDATE_CHAT_HISTORY_LOADING_STATE', payload: ChatHistoryLoadingState.Fail })
             dispatch({ type: 'SET_COSMOSDB_STATUS', payload: response })

--- a/frontend/src/state/AppReducer.tsx
+++ b/frontend/src/state/AppReducer.tsx
@@ -3,10 +3,12 @@ import { Action, AppState } from './AppProvider'
 // Define the reducer function
 export const appStateReducer = (state: AppState, action: Action): AppState => {
   switch (action.type) {
+    case 'SET_LOADING':
+      return { ...state, isLoading: action.payload }
     case 'TOGGLE_CHAT_HISTORY':
       return { ...state, isChatHistoryOpen: !state.isChatHistoryOpen }
     case 'UPDATE_CURRENT_CHAT':
-      return { ...state, currentChat: action.payload }
+      return { ...state, currentChat: action.payload, isLoading: false }
     case 'UPDATE_CHAT_HISTORY_LOADING_STATE':
       return { ...state, chatHistoryLoadingState: action.payload }
     case 'UPDATE_CHAT_HISTORY':

--- a/frontend/src/test/test.utils.tsx
+++ b/frontend/src/test/test.utils.tsx
@@ -20,7 +20,8 @@ const defaultMockState = {
   isGenerating: false,
   isRequestInitiated: false,
   failedSections : [],
-  isFailedReqInitiated : false
+  isFailedReqInitiated : false,
+  isLoading : false,
 };
 
 // Create a custom render function

--- a/start.cmd
+++ b/start.cmd
@@ -34,8 +34,7 @@ echo.
 echo Starting backend    
 echo.    
 
-cd ..  
-cd backend 
+cd ..
 
 start http://127.0.0.1:50505
 call python -m uvicorn app:app --port 50505 --reload 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request includes several changes to improve the chat functionality and refactor how chat history is fetched in the application. Chat History is being fetched only when the user clicks on the history button and not on the web page load, which in turn doesn't block the chat interface.

### Improvements to chat functionality:

* [`frontend/src/pages/chat/Chat.tsx`](diffhunk://#diff-acfbdb512c79eb9c53d0c2488f520793646422af0dac0a8c83b6c5080ffe784aR425-R427): Added fallback logic to use `currentChat` if a conversation is not found in `chatHistory` when fetching a conversation by ID. [[1]](diffhunk://#diff-acfbdb512c79eb9c53d0c2488f520793646422af0dac0a8c83b6c5080ffe784aR425-R427) [[2]](diffhunk://#diff-acfbdb512c79eb9c53d0c2488f520793646422af0dac0a8c83b6c5080ffe784aR466-R468) [[3]](diffhunk://#diff-acfbdb512c79eb9c53d0c2488f520793646422af0dac0a8c83b6c5080ffe784aR539-R541) [[4]](diffhunk://#diff-acfbdb512c79eb9c53d0c2488f520793646422af0dac0a8c83b6c5080ffe784aR597-R599)

### Refactoring chat history fetching logic:

* [`frontend/src/pages/layout/Layout.tsx`](diffhunk://#diff-a930475a94067349f398d3eeab82c557cfda92df5b3870b3699bbec04a5035c5R42-R84): Updated `handleHistoryClick` to fetch chat history if not already loaded and added a new `fetchChatHistory` function to handle the fetching process.
* [`frontend/src/state/AppProvider.tsx`](diffhunk://#diff-a8a4d7cc212da68d5bcad597f1673dfef6f159711885c7cc06df00ac7452cd3aL106-R112): Removed the `fetchChatHistory` function from the `useEffect` in `AppStateProvider` and refactored the logic to update the chat history loading state based on the response from `historyEnsure`.

### Import updates:

* [`frontend/src/pages/layout/Layout.tsx`](diffhunk://#diff-a930475a94067349f398d3eeab82c557cfda92df5b3870b3699bbec04a5035c5L6-R6): Added imports for `Conversation`, `historyList`, and `ChatHistoryLoadingState` from `../../api`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.


## Other Information
<!-- Add any other helpful information that may be needed here.. -->