### PR TITLE
fix: Document gets generated without title, if title is not added pre-export.

### DIFF
--- a/src/frontend/src/pages/draft/Draft.test.tsx
+++ b/src/frontend/src/pages/draft/Draft.test.tsx
@@ -130,7 +130,7 @@ describe('Draft Component', () => {
           { title: 'Section 2', content: 'Content of section 2.' }
         ]
       },
-      draftedDocumentTitle: '', // this must be explicitly ''
+      draftedDocumentTitle: 'My Draft Title',
     }
     renderComponent(mockStateWithIncompleteLoad)
     await waitFor(() => {
@@ -152,7 +152,7 @@ describe('Draft Component', () => {
           { title: 'Section 2', content: 'Content of section 2.' }
         ]
       },
-      draftedDocumentTitle: '', // critical for button to be enabled
+      draftedDocumentTitle: 'My Draft Title',
     }
     renderComponent(mockStateWithIncompleteLoad)
 
@@ -251,7 +251,7 @@ describe('Draft Component', () => {
           { title: 'Section 2', content: 'Content of section 2.' }
         ]
       },
-      draftedDocumentTitle: '', // must be empty string
+      draftedDocumentTitle: 'My Draft Title',
     }
     renderComponent(mockStateWithIncompleteLoad)
 
@@ -280,7 +280,7 @@ describe('Draft Component', () => {
           { title: 'Section 2', content: 'Content of section 2.' }
         ]
       },
-      draftedDocumentTitle: null // allow null here
+      draftedDocumentTitle: 'My Draft Title', // title should not be null
     }
     renderComponent(mockStateWithIncompleteLoad)
     await waitFor(async () => {

--- a/src/frontend/src/pages/draft/Draft.tsx
+++ b/src/frontend/src/pages/draft/Draft.tsx
@@ -50,7 +50,7 @@ const Draft = (): JSX.Element => {
 
   useEffect(() => {
     const title = draftedDocumentTitle ?? '' // Normalize null to ''
-    if (isLoadedSections?.length === sections.length && title === '') {
+    if (isLoadedSections?.length === sections.length && title.length > 0) {
       setIsExportButtonDisable(false);
     }
     else {


### PR DESCRIPTION
## Purpose
Document gets generated without title, if title is not added pre-export.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check

- Ask "Generate promissory note with a proposed $100,000 for Washington State" in "Generate" section
- Once proper response is generated, click on generate draft arrow to go to the draft section
- The same asked question will appear as a title in draft section
- Switch back to the generate section
- Refresh the screen and ask the same question again "Generate promissory note with a proposed $100,000 for Washington State"
- Now before moving to the draft section
- Ask it to "Remove Amendments Promissory Note" in "Generate" section
- Now move to the draft section by clicking on "generate draft arrow"
- Now observe there is no default title under title section. 


## Other Information
<!-- Add any other helpful information that may be needed here.. -->