### PR TITLE
chore: Removed approval step from Scheduled Dependabot PRs Auto-Merge

### DIFF
--- a/.github/workflows/Scheduled-Dependabot-PRs-Auto-Merge.yml
+++ b/.github/workflows/Scheduled-Dependabot-PRs-Auto-Merge.yml
@@ -57,11 +57,11 @@ jobs:
             mergeable=$(gh pr view "$pr_number" --json mergeable --jq '.mergeable')
             if [[ "$mergeable" == "CONFLICTING" ]]; then
               echo "❌ Merge conflicts detected. Rebasing PR #$pr_number"
-              gh pr rebase "$pr_url" || echo "❗ Rebase failed."
+              gh pr update-branch "$pr_url" || echo "❗ Rebase (update-branch) failed."
             fi
           done < matched_prs.txt
 
-      - name: Approve and Auto-Merge if Mergeable
+      - name: Auto-Merge if Mergeable
         if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -81,8 +81,6 @@ jobs:
               mergeable=$(gh pr view "$pr_number" --json mergeable --jq '.mergeable' 2>/dev/null || echo "UNKNOWN")
               echo "🔁 Attempt $((attempt+1))/$max_attempts: mergeable=$mergeable"
               if [[ "$mergeable" == "MERGEABLE" ]]; then
-                echo "✅ PR is mergeable. Approving..."
-                gh pr review --approve "$pr_url" || echo "❗ Approval failed."
                 echo "🚀 Enabling auto-merge..."
                 set -x
                 merge_output=$(gh pr merge --auto --merge "$pr_url" 2>&1)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Removing the approving step as its not required from Scheduled Dependabot PRs Auto-Merge yml file

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.


## Other Information
<!-- Add any other helpful information that may be needed here.. -->