### PR TITLE
feat: Added unit tests for Azure credential utilities

### DIFF
--- a/src/tests/unit_tests/helpers/test_azure_credential_utils.py
+++ b/src/tests/unit_tests/helpers/test_azure_credential_utils.py
@@ -1,0 +1,78 @@
+import pytest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+# Ensure src/backend is on the Python path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
+
+import backend.helpers.azure_credential_utils as azure_credential_utils
+
+# Synchronous tests
+
+@patch("backend.helpers.azure_credential_utils.os.getenv")
+@patch("backend.helpers.azure_credential_utils.DefaultAzureCredential")
+@patch("backend.helpers.azure_credential_utils.ManagedIdentityCredential")
+def test_get_azure_credential_dev_env(mock_managed_identity_credential, mock_default_azure_credential, mock_getenv):
+    """Test get_azure_credential in dev environment."""
+    mock_getenv.return_value = "dev"
+    mock_default_credential = MagicMock()
+    mock_default_azure_credential.return_value = mock_default_credential
+
+    credential = azure_credential_utils.get_azure_credential()
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_default_azure_credential.assert_called_once()
+    mock_managed_identity_credential.assert_not_called()
+    assert credential == mock_default_credential
+
+@patch("backend.helpers.azure_credential_utils.os.getenv")
+@patch("backend.helpers.azure_credential_utils.DefaultAzureCredential")
+@patch("backend.helpers.azure_credential_utils.ManagedIdentityCredential")
+def test_get_azure_credential_non_dev_env(mock_managed_identity_credential, mock_default_azure_credential, mock_getenv):
+    """Test get_azure_credential in non-dev environment."""
+    mock_getenv.return_value = "prod"
+    mock_managed_credential = MagicMock()
+    mock_managed_identity_credential.return_value = mock_managed_credential
+    credential = azure_credential_utils.get_azure_credential(client_id="test-client-id")
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
+    mock_default_azure_credential.assert_not_called()
+    assert credential == mock_managed_credential
+
+# Asynchronous tests
+
+@pytest.mark.asyncio
+@patch("backend.helpers.azure_credential_utils.os.getenv")
+@patch("backend.helpers.azure_credential_utils.AioDefaultAzureCredential")
+@patch("backend.helpers.azure_credential_utils.AioManagedIdentityCredential")
+async def test_get_azure_credential_async_dev_env(mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv):
+    """Test get_azure_credential_async in dev environment."""
+    mock_getenv.return_value = "dev"
+    mock_aio_default_credential = MagicMock()
+    mock_aio_default_azure_credential.return_value = mock_aio_default_credential
+
+    credential = await azure_credential_utils.get_azure_credential_async()
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_aio_default_azure_credential.assert_called_once()
+    mock_aio_managed_identity_credential.assert_not_called()
+    assert credential == mock_aio_default_credential
+
+@pytest.mark.asyncio
+@patch("backend.helpers.azure_credential_utils.os.getenv")
+@patch("backend.helpers.azure_credential_utils.AioDefaultAzureCredential")
+@patch("backend.helpers.azure_credential_utils.AioManagedIdentityCredential")
+async def test_get_azure_credential_async_non_dev_env(mock_aio_managed_identity_credential, mock_aio_default_azure_credential, mock_getenv):
+    """Test get_azure_credential_async in non-dev environment."""
+    mock_getenv.return_value = "prod"
+    mock_aio_managed_credential = MagicMock()
+    mock_aio_managed_identity_credential.return_value = mock_aio_managed_credential
+
+    credential = await azure_credential_utils.get_azure_credential_async(client_id="test-client-id")
+
+    mock_getenv.assert_called_once_with("APP_ENV", "prod")
+    mock_aio_managed_identity_credential.assert_called_once_with(client_id="test-client-id")
+    mock_aio_default_azure_credential.assert_not_called()
+    assert credential == mock_aio_managed_credential


### PR DESCRIPTION
## Purpose
This pull request introduces unit tests for the `get_azure_credential` and `get_azure_credential_async` functions in the `azure_credential_utils` module. The tests cover both synchronous and asynchronous scenarios, ensuring the functions behave correctly in different environments (development and non-development).

### Added Unit Tests for Azure Credential Utilities:

* **Synchronous Tests**:
  - Added `test_get_azure_credential_dev_env` to verify that `get_azure_credential` uses `DefaultAzureCredential` in a development environment.
  - Added `test_get_azure_credential_non_dev_env` to verify that `get_azure_credential` uses `ManagedIdentityCredential` in a non-development environment.

* **Asynchronous Tests**:
  - Added `test_get_azure_credential_async_dev_env` to verify that `get_azure_credential_async` uses `AioDefaultAzureCredential` in a development environment.
  - Added `test_get_azure_credential_async_non_dev_env` to verify that `get_azure_credential_async` uses `AioManagedIdentityCredential` in a non-development environment.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
- [x] I have built and tested the code locally and in a deployed app
- [x] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [x] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
