### PR TITLE
feat: Docgen Bicep Standard Changes - vars

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -236,88 +236,88 @@ module cosmosDBModule 'deploy_cosmos_db.bicep' = {
 }
 
 @description('Contains Storage Account Name')
-output storageAccountName string = storageAccount.outputs.storageName
+output STORAGE_ACCOUNT_NAME string = storageAccount.outputs.storageName
 
 @description('Contains Storage Container Name')
-output storageContainerName string = storageAccount.outputs.storageContainer
+output STORAGE_CONTAINER_NAME string = storageAccount.outputs.storageContainer
 
 @description('Contains KeyVault Name')
-output keyVaultName string = kvault.outputs.keyvaultName
+output KEY_VAULT_NAME string = kvault.outputs.keyvaultName
 
 @description('Contains CosmosDB Account Name')
-output cosmosDbAccountName string = cosmosDBModule.outputs.cosmosAccountName
+output COSMOSDB_ACCOUNT_NAME string = cosmosDBModule.outputs.cosmosAccountName
 
 @description('Contains Resource Group Name')
-output resourceGroupName string = resourceGroup().name
+output RESOURCE_GROUP_NAME string = resourceGroup().name
 
 @description('Contains AI Foundry Name')
-output aiFoundryName string = aifoundry.outputs.aiFoundryName
+output AI_FOUNDRY_NAME string = aifoundry.outputs.aiFoundryName
 
 @description('Contains AI Foundry RG Name')
-output aiFoundryRgName string = aifoundry.outputs.aiFoundryRgName
+output AI_FOUNDRY_RG_NAME string = aifoundry.outputs.aiFoundryRgName
 
 @description('Contains AI Foundry Resource ID')
-output aiFoundryResourceId string = aifoundry.outputs.aiFoundryId
+output AI_FOUNDRY_RESOURCE_ID string = aifoundry.outputs.aiFoundryId
 
 @description('Contains AI Search Service Name')
-output aiSearchServiceName string = aifoundry.outputs.aiSearchService
+output AI_SEARCH_SERVICE_NAME string = aifoundry.outputs.aiSearchService
 
 @description('Contains Azure Search Connection Name')
-output azureSearchConnectionName string = aifoundry.outputs.aiSearchConnectionName
+output AZURE_SEARCH_CONNECTION_NAME string = aifoundry.outputs.aiSearchConnectionName
 
 @description('Contains OpenAI Title Prompt')
-output azureOpenaiTitlePrompt string = appserviceModule.outputs.azureOpenAiTitlePrompt
+output AZURE_OPENAI_TITLE_PROMPT string = appserviceModule.outputs.azureOpenAiTitlePrompt
 
 @description('Contains OpenAI Generate Section Content Prompt')
-output azureOpenaiGenerateSectionContentPrompt string = appserviceModule.outputs.azureOpenAiGenerateSectionContentPrompt
+output AZURE_OPENAI_GENERATE_SECTION_CONTENT_PROMPT string = appserviceModule.outputs.azureOpenAiGenerateSectionContentPrompt
 
 @description('Contains OpenAI Template System Message')
-output azureOpenaiTemplateSystemMessage string = appserviceModule.outputs.azureOpenAiTemplateSystemMessage
+output AZURE_OPENAI_TEMPLATE_SYSTEM_MESSAGE string = appserviceModule.outputs.azureOpenAiTemplateSystemMessage
 
 @description('Contains OpenAI System Message')
-output azureOpenaiSystemMessage string = appserviceModule.outputs.azureOpenAISystemMessage
+output AZURE_OPENAI_SYSTEM_MESSAGE string = appserviceModule.outputs.azureOpenAISystemMessage
 
 @description('Contains OpenAI Model')
-output azureOpenaiModel string = appserviceModule.outputs.azureOpenAIModel
+output AZURE_OPENAI_MODEL string = appserviceModule.outputs.azureOpenAIModel
 
 @description('Contains OpenAI Resource')
-output azureOpenaiResource string = appserviceModule.outputs.azureOpenAIResource
+output AZURE_OPENAI_RESOURCE string = appserviceModule.outputs.azureOpenAIResource
 
 @description('Contains Azure Search Service')
-output azureSearchService string = appserviceModule.outputs.aiSearchService
+output AZURE_SEARCH_SERVICE string = appserviceModule.outputs.aiSearchService
 
 @description('Contains Azure Search Index')
-output azureSearchIndex string = appserviceModule.outputs.AzureSearchIndex
+output AZURE_SEARCH_INDEX string = appserviceModule.outputs.AzureSearchIndex
 
 @description('Contains CosmosDB Account')
-output azureCosmosDbAccount string = cosmosDBModule.outputs.cosmosAccountName
+output AZURE_COSMOSDB_ACCOUNT string = cosmosDBModule.outputs.cosmosAccountName
 
 @description('Contains CosmosDB Database')
-output azureCOSMOSDB_DATABASE string = cosmosDBModule.outputs.cosmosDatabaseName
+output AZURE_COSMOSDB_DATABASE string = cosmosDBModule.outputs.cosmosDatabaseName
 
 @description('Contains CosmosDB Conversations Container')
-output azureCosmosDbConversationsContainer string = cosmosDBModule.outputs.cosmosContainerName
+output AZURE_COSMOSDB_CONVERSATIONS_CONTAINER string = cosmosDBModule.outputs.cosmosContainerName
 
 @description('Contains CosmosDB Enabled Feedback')
-output azureCosmosDbEnableFeedback string = appserviceModule.outputs.azureCosmosDbEnableFeedback
+output AZURE_COSMOSDB_ENABLE_FEEDBACK string = appserviceModule.outputs.azureCosmosDbEnableFeedback
 
 @description('Contains Search Query Type')
-output azureSearchQueryType string = appserviceModule.outputs.AzureSearchQueryType
+output AZURE_SEARCH_QUERY_TYPE string = appserviceModule.outputs.AzureSearchQueryType
 
 @description('Contains Search Vector Columns')
-output azureSearchVectorColumns string = appserviceModule.outputs.AzureSearchVectorFields
+output AZURE_SEARCH_VECTOR_COLUMNS string = appserviceModule.outputs.AzureSearchVectorFields
 
 @description('Contains AI Agent Endpoint')
-output azureAiAgentEndpoint string = aifoundry.outputs.aiFoundryProjectEndpoint
+output AZURE_AI_AGENT_ENDPOINT string = aifoundry.outputs.aiFoundryProjectEndpoint
 
 @description('Contains AI Agent API Version')
-output azureAiAgentApiVersion string = azureAiAgentApiVersion
+output AZURE_AI_AGENT_API_VERSION string = azureAiAgentApiVersion
 
 @description('Contains AI Agent Model Deployment Name')
-output azureAiAgentModelDeploymentName string = appserviceModule.outputs.azureOpenAIModel
+output AZURE_AI_AGENT_MODEL_DEPLOYMENT_NAME string = appserviceModule.outputs.azureOpenAIModel
 
 @description('Contains Application Insights Connection String')
-output azureApplicationInsightsConnectionString string = aifoundry.outputs.applicationInsightsConnectionString
+output AZURE_APPLICATION_INSIGHTS_CONNECTION_STRING string = aifoundry.outputs.applicationInsightsConnectionString
 
 @description('Contains Application Environment.')
-output appEnv string  = appserviceModule.outputs.appEnv
+output APP_ENV string  = appserviceModule.outputs.appEnv


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request introduces significant improvements to the Azure infrastructure deployment scripts, focusing on standardizing parameter names, supporting resource tagging, and enhancing output variables for better integration and management. The changes primarily update the Bicep templates and deployment workflows to align with best practices, improve maintainability, and provide more flexibility for resource configuration.

**Key changes include:**

### Standardization and Parameterization

- Standardized parameter names across Bicep modules (e.g., `solutionName`, `hostingPlanName`, `websiteName`) and added descriptions to improve clarity and consistency in `infra/deploy_ai_foundry.bicep`, `infra/deploy_app_service.bicep`, and related files. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R2-R57) [[2]](diffhunk://#diff-37c8b5694d17291d641a19fb8a562e30642066b4bf8b8657f2636f50567cf4ebL12-R105) [[3]](diffhunk://#diff-85f6bac0ba41825094723b2a6a0963c6b562b081d5d06e93b0901af0c0902c7fR1-R21)
- Updated the deployment workflow (`.github/workflows/deploy.yml`) to use `solutionName` instead of `environmentName` for consistency with Bicep modules.

### Resource Tagging Support

- Introduced a `tags` parameter (with default empty object) to multiple Bicep files and ensured all major Azure resources (e.g., Log Analytics, Application Insights, Cognitive Services, Key Vault secrets, Search services) propagate this `tags` object, enabling consistent resource tagging for management and cost tracking. [[1]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626L94-R131) [[2]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R144) [[3]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R173) [[4]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R187) [[5]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R206) [[6]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R233) [[7]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R262) [[8]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R280) [[9]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R342) [[10]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R352) [[11]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R361) [[12]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R372) [[13]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R381) [[14]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R390) [[15]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R399) [[16]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R408) [[17]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R419) [[18]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R430) [[19]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R439) [[20]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R448) [[21]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R457) [[22]](diffhunk://#diff-801321770c4260aea129a24ab905704034ec515f2811ee5d93a6fc7c2d29c626R466-R521) [[23]](diffhunk://#diff-85f6bac0ba41825094723b2a6a0963c6b562b081d5d06e93b0901af0c0902c7fR1-R21)

### Output Enhancements

- Added numerous output variables to `infra/deploy_ai_foundry.bicep` for key resource names, IDs, endpoints, and connection strings, making it easier to integrate deployed resources with downstream systems or modules.

### Naming Conventions

- Replaced dynamic abbreviations with fixed resource name prefixes (e.g., `aif-`, `appi-`, `kv-`, `srch-`, `log-`) for resource names, improving predictability and reducing dependency on external abbreviation files.

### Miscellaneous Improvements

- Added or updated parameters in `infra/deploy_app_service.bicep` to support additional configuration options such as API versions, enabling/disabling chat history, and specifying AI resource/project details.

These changes collectively improve the maintainability, clarity, and operational flexibility of the Azure deployment process.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.


## Other Information
<!-- Add any other helpful information that may be needed here.. -->