### PR TITLE
docs: Updated README, azure.yml for minimum azd version 1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Quick deploy
 ### How to install or deploy
 Follow the quick deploy steps on the deployment guide to deploy this solution to your own Azure subscription.
 
+> **Note:** This solution accelerator requires **Azure Developer CLI (azd) version 1.18.0 or higher**. Please ensure you have the latest version installed before proceeding with deployment. [Download azd here](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
+
 [Click here to launch the deployment guide](./docs/DeploymentGuide.md)
 <br/><br/>
 

--- a/azure.yaml
+++ b/azure.yaml
@@ -7,7 +7,7 @@ metadata:
   template: document-generation@1.0
 
 requiredVersions:
-  azd: '>= 1.15.0'
+  azd: '>= 1.18.0'
 
 parameters:
   solutionPrefix:

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -112,7 +112,7 @@ If you're not using one of the above options for opening the project, then you'l
 
 1. Make sure the following tools are installed:
     - [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.5) <small>(v7.0+)</small> - available for Windows, macOS, and Linux. (Required for Windows users only. Follow the steps [here](./PowershellSetup.md) to add it to the Windows PATH.)
-    - [Azure Developer CLI (azd)](https://aka.ms/install-azd) <small>(v1.15.0+)</small> - version
+    - [Azure Developer CLI (azd)](https://aka.ms/install-azd) <small>(v1.18.0+)</small> - version
     - [Python 3.9+](https://www.python.org/downloads/)
     - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
     - [Git](https://git-scm.com/downloads)
@@ -208,6 +208,7 @@ Once you've opened the project in [Codespaces](#github-codespaces), [Dev Contain
     ```shell
     azd up
     ```
+    > **Note:** This solution accelerator requires **Azure Developer CLI (azd) version 1.18.0 or higher**. Please ensure you have the latest version installed before proceeding with deployment. [Download azd here](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
 
 3. Provide an `azd` environment name (e.g., "dgapp").
 4. Select a subscription from your Azure account and choose a location that has quota for all the resources. 


### PR DESCRIPTION
## Purpose
This pull request updates the minimum required version of the Azure Developer CLI (azd) from 1.15.0 to 1.18.0 throughout the documentation and configuration files. It also adds clearer guidance to users about this requirement in the deployment instructions.

**Minimum azd version requirement updates:**

* Increased the minimum required version of `azd` from 1.15.0 to 1.18.0 in the `azure.yaml` configuration file.
* Updated the version requirement for `azd` in the tool prerequisites list in `docs/DeploymentGuide.md`.

**Documentation improvements:**

* Added a prominent note in the `README.md` quick deploy section to inform users that `azd` version 1.18.0 or higher is required, including a download link.
* Added a similar note in the deployment steps of `docs/DeploymentGuide.md` to remind users to verify their `azd` version before proceeding.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
