### PR TITLE
docs: Post deployment script and read me file changes

### DIFF
--- a/docs/AVMPostDeploymentGuide.md
+++ b/docs/AVMPostDeploymentGuide.md
@@ -1,6 +1,6 @@
 # AVM Post Deployment Guide
 
-This document provides guidance on post-deployment steps after deploying the Document Generation Solution Accelerator from the AVM.
+This document provides guidance on post-deployment steps after deploying the Document Generation Solution Accelerator from the AVM(Azure Verified Modules).
  
  ---
 
@@ -19,11 +19,7 @@ This document provides guidance on post-deployment steps after deploying the Doc
     ```bash 
     ./infra/scripts/process_sample_data.sh <resourceGroupName> 
     ```
-    If the deployment has been deleted from the Azure portal, you will need to pass additional parameters along with the command. In that case, the command will look like the following:
-
-    ```bash
-        ./infra/scripts/process_sample_data.sh <resourceGroupName> <cosmosDbAccountName> <storageAccount> <storageContainerName> <keyvaultName> <sqlServerName> <sqlDatabaseName> <webAppUserManagedIdentityClientId> <webAppUserManagedIdentityDisplayName> <aiFoundryResourceName> <aiSearchResourceName> <azSubscriptionId>
-    ```
+    If the deployment does not exist or has been deleted – The script will prompt you to manually enter the required values
 
 1. Add App Authentication
 

--- a/docs/PostDeploymentsteps.md
+++ b/docs/PostDeploymentsteps.md
@@ -1,0 +1,38 @@
+# AVM Post Deployment Guide
+
+This document provides guidance on post-deployment steps after deploying the Document Generation Solution Accelerator from the AVM.
+ 
+ ---
+
+### Add Sample data
+1. Clone the Repository
+    First, clone this repository to access the post-deployment scripts:
+    ```bash
+    git clone https://github.com/microsoft/document-generation-solution-accelerator.git
+    ```
+    ```bash
+    cd document-generation-solution-accelerato
+    ```
+
+2. Import Sample Data -Run bash command printed in the terminal. The bash command will look like the following:
+
+    ```bash 
+    ./infra/scripts/process_sample_data.sh <resourceGroupName> 
+    ```
+    If the deployment has been deleted from the Azure portal, you will need to pass additional parameters along with the command. In that case, the command will look like the following:
+
+    ```bash
+        ./infra/scripts/process_sample_data.sh <resourceGroupName> <cosmosDbAccountName> <storageAccount> <storageContainerName> <keyvaultName> <sqlServerName> <sqlDatabaseName> <webAppUserManagedIdentityClientId> <webAppUserManagedIdentityDisplayName> <aiFoundryResourceName> <aiSearchResourceName> <azSubscriptionId>
+    ```
+
+1. Add App Authentication
+
+    > Note: Authentication changes can take up to 10 minutes
+
+    Follow steps in [App Authentication](https://github.com/microsoft/document-generation-solution-accelerator/blob/psl-postdeployentscript-new/docs/AppAuthentication.md) to configure authentication in app service.
+
+1. Deleting Resources After a Failed Deployment
+
+    Follow steps in [Delete Resource Group](https://github.com/microsoft/document-generation-solution-accelerator/blob/psl-postdeployentscript-new/docs/DeleteResourceGroup.md) if your deployment fails and/or you need to clean up the resources.
+
+    

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -273,6 +273,7 @@ resource resourceGroupTags 'Microsoft.Resources/tags@2021-04-01' = {
       TemplateName: 'DocGen'
       Type: enablePrivateNetworking ? 'WAF' : 'Non-WAF'
       CreatedBy: createdBy
+      DeploymentName: deployment().name
     }
   }
 }
@@ -1181,3 +1182,7 @@ output AZURE_APPLICATION_INSIGHTS_CONNECTION_STRING string = (enableMonitoring &
 
 @description('Contains Application Environment.')
 output APP_ENV string  = appEnvironment
+@description('Contains Subscription ID')
+output SubscriptionId string = subscription().subscriptionId
+@description('Contains Managed Identity Client ID')
+output MANAGED_IDENTITY_CLIENT_ID string = userAssignedIdentity.outputs.clientId

--- a/infra/scripts/process_sample_data.sh
+++ b/infra/scripts/process_sample_data.sh
@@ -2,14 +2,6 @@
 
 # Variables
 resourceGroupName="$1"
-cosmosDbAccountName="$2"
-storageAccount="$3"
-filesystem="$4"
-keyvaultName="$5"
-managedIdentityClientId="$6"
-aiSearchName="$7"
-aif_resource_id="$8"
-azSubscriptionId="$9"
 
 # Global variables to track original network access states
 original_storage_public_access=""
@@ -252,38 +244,55 @@ fi
 # get parameters from deployment
 deploymentName=$(az group show --name "$resourceGroupName" --query "tags.DeploymentName" -o tsv) 
 echo "Deployment Name (from tag): $deploymentName"
-cosmosDbAccountName=$(az deployment group show \
-    --name "$deploymentName" \
-    --resource-group "$resourceGroupName" \
-    --query "properties.outputs.cosmosdB_ACCOUNT_NAME.value" -o tsv)
-storageAccount=$(az deployment group show \
-    --name "$deploymentName" \
-    --resource-group "$resourceGroupName" \
-    --query "properties.outputs.storagE_ACCOUNT_NAME.value" -o tsv)
-fileSystem=$(az deployment group show \
-    --name "$deploymentName" \
-    --resource-group "$resourceGroupName" \
-    --query "properties.outputs.storagE_CONTAINER_NAME.value" -o tsv)
-keyvaultName=$(az deployment group show \
-    --name "$deploymentName" \
-    --resource-group "$resourceGroupName" \
-    --query "properties.outputs.keY_VAULT_NAME.value" -o tsv)
-managedIdentityClientId=$(az deployment group show \
-    --name "$deploymentName" \
-    --resource-group "$resourceGroupName" \
-    --query "properties.outputs.manageD_IDENTITY_CLIENT_ID.value" -o tsv)
-aiSearchName=$(az deployment group show \
-    --name "$deploymentName" \
-    --resource-group "$resourceGroupName" \
-    --query "properties.outputs.aI_SEARCH_SERVICE_NAME.value" -o tsv)
-aif_resource_id=$(az deployment group show \
-    --name "$deploymentName" \
-    --resource-group "$resourceGroupName" \
-    --query "properties.outputs.aI_FOUNDRY_RESOURCE_ID.value" -o tsv)
-azSubscriptionId=$(az deployment group show \
-    --name "$deploymentName" \
-    --resource-group "$resourceGroupName" \
-    --query "properties.outputs.subscriptionId.value" -o tsv)
+
+if az deployment group show --resource-group "$resourceGroupName" --name "$deploymentName" &>/dev/null; then
+    cosmosDbAccountName=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs.cosmosdB_ACCOUNT_NAME.value" -o tsv)
+    storageAccount=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs.storagE_ACCOUNT_NAME.value" -o tsv)
+    fileSystem=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs.storagE_CONTAINER_NAME.value" -o tsv)
+    keyvaultName=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs.keY_VAULT_NAME.value" -o tsv)
+    managedIdentityClientId=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs.manageD_IDENTITY_CLIENT_ID.value" -o tsv)
+    aiSearchName=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs.aI_SEARCH_SERVICE_NAME.value" -o tsv)
+    aif_resource_id=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs.aI_FOUNDRY_RESOURCE_ID.value" -o tsv)
+    azSubscriptionId=$(az deployment group show \
+        --name "$deploymentName" \
+        --resource-group "$resourceGroupName" \
+        --query "properties.outputs.subscriptionId.value" -o tsv)
+else
+    #echo "Deployment does NOT exist/deleted in resource group $resourceGroupName"
+    echo "Deployment does NOT exist in resource group $resourceGroupName."
+    echo "Please enter required values manually."
+
+    read -rp "Enter Cosmos DB Account Name: " cosmosDbAccountName
+    read -rp "Enter Storage Account Name: " storageAccount
+    read -rp "Enter Storage Container/File System Name: " fileSystem
+    read -rp "Enter Key Vault Name: " keyvaultName
+    read -rp "Enter Managed Identity Client ID: " managedIdentityClientId
+    read -rp "Enter AI Search Service Name: " aiSearchName
+    read -rp "Enter AI Foundry Resource ID: " aif_resource_id
+    read -rp "Enter Azure Subscription ID: " azSubscriptionId
+fi  
+
 # Check if all required arguments are provided
 if [ -z "$storageAccount" ] || [ -z "$fileSystem" ] || [ -z "$keyvaultName" ] || [ -z "$cosmosDbAccountName" ] || [ -z "$resourceGroupName" ] || [ -z "$aif_resource_id" ] || [ -z "$aiSearchName" ]; then
     echo "Usage: $0 <storageAccount> <storageContainerName> <keyvaultName> <cosmosDbAccountName> <resourceGroupName> <aiSearchName> <managedIdentityClientId> <aif_resource_id>"

--- a/infra/scripts/process_sample_data.sh
+++ b/infra/scripts/process_sample_data.sh
@@ -2,6 +2,14 @@
 
 # Variables
 resourceGroupName="$1"
+cosmosDbAccountName="$2"
+storageAccount="$3"
+filesystem="$4"
+keyvaultName="$5"
+managedIdentityClientId="$6"
+aiSearchName="$7"
+aif_resource_id="$8"
+azSubscriptionId="$9"
 
 # Global variables to track original network access states
 original_storage_public_access=""


### PR DESCRIPTION
## Purpose
This pull request introduces several improvements to the post-deployment experience for the Document Generation Solution Accelerator, focusing on better guidance, automation, and resource tagging. The main changes include the addition of a comprehensive post-deployment guide, enhancements to the sample data import script for improved parameter handling and Azure authentication, and updates to the infrastructure code for more informative outputs and resource tagging.

**Documentation improvements:**
* Added a new `AVMPostDeploymentGuide.md` that provides step-by-step instructions for post-deployment tasks, including importing sample data, configuring authentication, and cleaning up resources after failed deployments.

**Sample data import automation:**
* Refactored `process_sample_data.sh` to automatically retrieve deployment parameters from Azure resource group tags and deployment outputs, with fallback to manual input if the deployment does not exist. Also added Azure CLI authentication logic for smoother script execution. [[1]](diffhunk://#diff-5f42277e379c1334fbdc9a52828c031d1620d82b99cded3dc825000a68e0ae0cL4-R4) [[2]](diffhunk://#diff-5f42277e379c1334fbdc9a52828c031d1620d82b99cded3dc825000a68e0ae0cL244-L277)

**Infrastructure outputs and tagging:**
* Updated `main.bicep` to output additional deployment metadata, including the subscription ID and managed identity client ID, which improves traceability and supports downstream automation.
* Added a `DeploymentName` tag to the resource group for easier identification and correlation of resources with deployments.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.


## Other Information
<!-- Add any other helpful information that may be needed here.. -->