### PR TITLE
fix: Fixing of EXP Deployment - Bug#33406

### DIFF
--- a/content-gen/infra/modules/deploy_foundry_role_assignment.bicep
+++ b/content-gen/infra/modules/deploy_foundry_role_assignment.bicep
@@ -1,0 +1,84 @@
+// ========== existing-ai-services-roles.bicep ========== //
+// Module to assign RBAC roles to managed identity on an existing AI Services account
+// This is required when reusing an existing AI Foundry project from a different resource group
+
+@description('Required. The principal ID of the managed identity to grant access.')
+param principalId string
+
+@description('Required. The name of the existing AI Services account.')
+param aiServicesName string
+
+@description('Optional. The name of the existing AI Project.')
+param aiProjectName string = ''
+
+@description('Optional. The principal type of the identity.')
+@allowed([
+  'Device'
+  'ForeignGroup'
+  'Group'
+  'ServicePrincipal'
+  'User'
+])
+param principalType string = 'ServicePrincipal'
+
+// ========== Role Definitions ========== //
+
+// Azure AI User role - for AI Foundry project access (used by AIProjectClient for image generation)
+resource azureAiUserRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  name: '53ca6127-db72-4b80-b1b0-d745d6d5456d'
+}
+
+// Cognitive Services OpenAI User role - for chat completions (used by AzureOpenAIChatClient)
+resource cognitiveServicesOpenAiUserRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  name: '5e0bd9bd-7b93-4f28-af87-19fc36ad61bd'
+}
+
+// ========== Existing Resources ========== //
+
+// Reference the existing AI Services account
+resource existingAiServices 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' existing = {
+  name: aiServicesName
+}
+
+// Reference the existing AI Project (if provided)
+resource existingAiProject 'Microsoft.CognitiveServices/accounts/projects@2025-04-01-preview' existing = if (!empty(aiProjectName)) {
+  name: aiProjectName
+  parent: existingAiServices
+}
+
+// ========== Role Assignments ========== //
+
+// Azure AI User role assignment - same as reference accelerator
+// Required for AIProjectClient (used for image generation in Foundry mode)
+resource assignAzureAiUserRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(existingAiServices.id, principalId, azureAiUserRole.id)
+  scope: existingAiServices
+  properties: {
+    roleDefinitionId: azureAiUserRole.id
+    principalId: principalId
+    principalType: principalType
+  }
+}
+
+// Cognitive Services OpenAI User role assignment
+// Required for AzureOpenAIChatClient (used for chat completions)
+resource assignCognitiveServicesOpenAiUserRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(existingAiServices.id, principalId, cognitiveServicesOpenAiUserRole.id)
+  scope: existingAiServices
+  properties: {
+    roleDefinitionId: cognitiveServicesOpenAiUserRole.id
+    principalId: principalId
+    principalType: principalType
+  }
+}
+
+// ========== Outputs ========== //
+
+@description('The resource ID of the existing AI Services account.')
+output aiServicesResourceId string = existingAiServices.id
+
+@description('The endpoint of the existing AI Services account.')
+output aiServicesEndpoint string = existingAiServices.properties.endpoint
+
+@description('The principal ID of the existing AI Project (if provided).')
+output aiProjectPrincipalId string = !empty(aiProjectName) ? existingAiProject.identity.principalId : ''


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
This pull request adds support for assigning required RBAC roles to a managed identity when reusing an existing Azure AI Foundry project from a different resource group or subscription. The main changes introduce a new Bicep module for role assignment and update the infrastructure deployment logic to call this module when an existing AI Foundry project is used.

**Role Assignment for Existing AI Services:**

* Added a new Bicep module `modules/deploy_foundry_role_assignment.bicep` that assigns the necessary RBAC roles (`Azure AI User` and `Cognitive Services OpenAI User`) to a managed identity on an existing AI Services account. This ensures the identity has the correct permissions for both image generation and chat completions.
* Updated `content-gen/infra/main.bicep` to deploy the new role assignment module (`existingAiServicesRoleAssignments`) when an existing AI Foundry project is specified, passing in the required parameters and scoping the deployment to the correct resource group and subscription.

**Subscription ID Handling:**

* Fixed the logic in `content-gen/infra/main.bicep` to correctly extract the subscription ID from the existing AI project resource ID, ensuring deployments are scoped to the proper subscription when using an existing AI Foundry project.