### PR TITLE
fix: added allowed regions for ai service location

### DIFF
--- a/content-gen/infra/main.bicep
+++ b/content-gen/infra/main.bicep
@@ -38,6 +38,20 @@ param secondaryLocation string = 'uksouth'
 
 // NOTE: Metadata must be compile-time constants. Update usageName manually if you change model parameters.
 // Format: 'OpenAI.<DeploymentType>.<ModelName>,<Capacity>'
+// Allowed regions: Union of GPT-5.1, gpt-image-1, and gpt-image-1.5 GlobalStandard availability
+@allowed([
+  'australiaeast'
+  'canadaeast'
+  'eastus2'
+  'japaneast'
+  'koreacentral'
+  'polandcentral'
+  'swedencentral'
+  'switzerlandnorth'
+  'uaenorth'
+  'uksouth'
+  'westus3'
+])
 @metadata({
   azd: {
     type: 'location'

--- a/content-gen/infra/main.json
+++ b/content-gen/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "8403017938611050215"
+      "templateHash": "14662930066054172114"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -62,6 +62,19 @@
     },
     "azureAiServiceLocation": {
       "type": "string",
+      "allowedValues": [
+        "australiaeast",
+        "canadaeast",
+        "eastus2",
+        "japaneast",
+        "koreacentral",
+        "polandcentral",
+        "swedencentral",
+        "switzerlandnorth",
+        "uaenorth",
+        "uksouth",
+        "westus3"
+      ],
       "metadata": {
         "azd": {
           "type": "location",
@@ -14019,8 +14032,8 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "virtualNetwork"
       ]
     },


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure deployment templates to restrict the allowed Azure regions for AI services to a specific set where the required models are globally available. It ensures that both the Bicep and generated JSON templates consistently enforce these region restrictions, and corrects the dependency order in the deployment resources.

**Region restriction updates:**

* Updated the `secondaryLocation` parameter in `main.bicep` to allow only regions where GPT-5.1, gpt-image-1, and gpt-image-1.5 are globally available.
* Added an `allowedValues` list to the `azureAiServiceLocation` parameter in `main.json` to enforce the same set of allowed regions as in the Bicep template.

**Template and deployment corrections:**

* Updated the `templateHash` in `main.json` to reflect changes in the template.
* Fixed the order of dependencies in the deployment resources to ensure `cognitiveServices` DNS zone is referenced before `openAI` in `main.json`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
