### PR TITLE
fix: main to dev downmerge

### DIFF
--- a/content-gen/infra/main.bicep
+++ b/content-gen/infra/main.bicep
@@ -38,6 +38,20 @@ param secondaryLocation string = 'uksouth'
 
 // NOTE: Metadata must be compile-time constants. Update usageName manually if you change model parameters.
 // Format: 'OpenAI.<DeploymentType>.<ModelName>,<Capacity>'
+// Allowed regions: Union of GPT-5.1, gpt-image-1, and gpt-image-1.5 GlobalStandard availability
+@allowed([
+  'australiaeast'
+  'canadaeast'
+  'eastus2'
+  'japaneast'
+  'koreacentral'
+  'polandcentral'
+  'swedencentral'
+  'switzerlandnorth'
+  'uaenorth'
+  'uksouth'
+  'westus3'
+])
 @metadata({
   azd: {
     type: 'location'

--- a/content-gen/infra/main.json
+++ b/content-gen/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.40.2.10011",
-      "templateHash": "8403017938611050215"
+      "templateHash": "14662930066054172114"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -62,6 +62,19 @@
     },
     "azureAiServiceLocation": {
       "type": "string",
+      "allowedValues": [
+        "australiaeast",
+        "canadaeast",
+        "eastus2",
+        "japaneast",
+        "koreacentral",
+        "polandcentral",
+        "swedencentral",
+        "switzerlandnorth",
+        "uaenorth",
+        "uksouth",
+        "westus3"
+      ],
       "metadata": {
         "azd": {
           "type": "location",
@@ -14019,8 +14032,8 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "virtualNetwork"
       ]
     },


### PR DESCRIPTION
## Purpose
This pull request updates the infrastructure configuration for the content generation solution, focusing on restricting allowed deployment regions for Azure AI services and making a minor dependency ordering fix. The changes ensure that deployments are limited to supported regions and improve template consistency.

**Region restriction and validation:**

* Added an explicit list of allowed Azure regions for AI service deployment in both `main.bicep` and `main.json`. This ensures that only supported regions (e.g., `australiaeast`, `eastus2`, `uksouth`, etc.) can be selected, aligning with the availability of specific AI models. [[1]](diffhunk://#diff-efe7d19975275715c4245a3143efddd07b6574086cb73e487e0a01b814a30941R41-R54) [[2]](diffhunk://#diff-c8116c3440c723b71cfc6406d5e38f686a6ebbb8f2affb0c806ff443d9cbf297R65-R77)

**Infrastructure and template consistency:**

* Updated the ARM template hash in `main.json` to reflect the changes made in the Bicep template.

**Dependency fix:**

* Corrected the order of dependencies for AI service resources in `main.json` to ensure proper deployment sequencing, specifically adjusting the placement of the `openAI` and `cognitiveServices` private DNS zones.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
