### PR TITLE
fix: Update descriptive text content on product/color change during image regeneration

### DIFF
--- a/content-gen/src/app/frontend/src/App.tsx
+++ b/content-gen/src/app/frontend/src/App.tsx
@@ -360,8 +360,27 @@ function App() {
                 
                 // Update generatedContent with new image
                 if (parsedContent.image_url || parsedContent.image_base64) {
+                  // Build updated text_content: if the product/color changed,
+                  // replace the old product name in all text fields so the
+                  // body copy, headline, tagline etc. reflect the new color.
+                  let updatedTextContent = generatedContent.text_content;
+                  if (mentionedProduct && selectedProducts[0] && generatedContent.text_content) {
+                    const oldName = selectedProducts[0].product_name;
+                    const newName = mentionedProduct.product_name;
+                    if (oldName && newName && oldName.toLowerCase() !== newName.toLowerCase()) {
+                      const regex = new RegExp(oldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+                      updatedTextContent = {
+                        headline: generatedContent.text_content.headline?.replace(regex, newName),
+                        body: generatedContent.text_content.body?.replace(regex, newName),
+                        cta_text: generatedContent.text_content.cta_text?.replace(regex, newName),
+                        tagline: generatedContent.text_content.tagline?.replace(regex, newName),
+                      };
+                    }
+                  }
+
                   responseData = {
                     ...generatedContent,
+                    text_content: updatedTextContent,
                     image_content: {
                       ...generatedContent.image_content,
                       image_url: parsedContent.image_url || generatedContent.image_content?.image_url,


### PR DESCRIPTION
## Purpose
When a user regenerates an image with a different product/color (e.g., changing from "Porcelain Mist" to "Pine Shadow"), the image and product label updated correctly, but the descriptive text content (headline, body copy, tagline, CTA) still referenced the old color name. Additionally, navigating away from the conversation and returning would revert to the stale text from CosmosDB.

This PR ensures that when a product/color change is detected during image regeneration:

1. Frontend (App.tsx): All text_content fields are immediately updated via case-insensitive find-and-replace of the old product name with the new one, giving the user instant visual feedback.
2. Backend (app.py): Before persisting generated_content to CosmosDB, the regenerate endpoint compares old vs. new selected_products and replaces the old product name in text_content. This guarantees the updated text is restored correctly when the user navigates back to the conversation.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
