### PR TITLE
fix: prevent new conversation action when no messages are present

### DIFF
--- a/content-gen/src/app/frontend/src/components/ChatHistory.tsx
+++ b/content-gen/src/app/frontend/src/components/ChatHistory.tsx
@@ -279,15 +279,15 @@ export function ChatHistory({
             </Link>
           )}
           <Link
-            onClick={isGenerating ? undefined : onNewConversation}
+            onClick={(isGenerating || currentMessages.length === 0) ? undefined : onNewConversation}
             style={{
               display: 'flex',
               alignItems: 'center',
               gap: '8px',
               fontSize: '13px',
-              color: isGenerating ? tokens.colorNeutralForegroundDisabled : tokens.colorNeutralForeground1,
-              cursor: isGenerating ? 'not-allowed' : 'pointer',
-              pointerEvents: isGenerating ? 'none' : 'auto',
+              color: (isGenerating || currentMessages.length === 0) ? tokens.colorNeutralForegroundDisabled : tokens.colorNeutralForeground1,
+              cursor: (isGenerating || currentMessages.length === 0) ? 'not-allowed' : 'pointer',
+              pointerEvents: (isGenerating || currentMessages.length === 0) ? 'none' : 'auto',
             }}
           >
             <Compose20Regular />

--- a/content-gen/src/app/frontend/src/components/ChatPanel.tsx
+++ b/content-gen/src/app/frontend/src/components/ChatPanel.tsx
@@ -286,7 +286,7 @@ export function ChatPanel({
                 icon={<Add20Regular />}
                 size="small"
                 onClick={onNewConversation}
-                disabled={isLoading}
+                disabled={isLoading || messages.length === 0}
                 style={{ 
                   minWidth: '32px',
                   height: '32px',


### PR DESCRIPTION
## Purpose

This pull request updates the logic for enabling and disabling the "New Conversation" action in the chat UI to prevent users from starting a new conversation when there are no messages or when a generation/loading process is in progress. This improves the user experience by disabling the button and link in scenarios where starting a new conversation would not make sense.

**Improvements to chat action availability:**

* In `ChatHistory.tsx`, the "New Conversation" link is now disabled not only when a message is generating (`isGenerating`), but also when there are no current messages (`currentMessages.length === 0`). The visual styles and pointer events are updated accordingly.
* In `ChatPanel.tsx`, the "New Conversation" button is disabled when either the chat is loading (`isLoading`) or there are no messages (`messages.length === 0`).

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify deployment and GP testing

