### PR TITLE
fix: code quality

### DIFF
--- a/src/tests/services/test_orchestrator.py
+++ b/src/tests/services/test_orchestrator.py
@@ -3,7 +3,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import orchestrator as orch_module
+import orchestrator
 from orchestrator import (_HARMFUL_PATTERNS_COMPILED,
                           _SYSTEM_PROMPT_PATTERNS_COMPILED,
                           PLANNING_INSTRUCTIONS, RAI_HARMFUL_CONTENT_RESPONSE,
@@ -840,7 +840,7 @@ def test_get_orchestrator_singleton():
         mock_builder.return_value = mock_builder_instance
 
         # Reset the singleton
-        orch_module._orchestrator = None
+        orchestrator._orchestrator = None
 
         instance1 = get_orchestrator()
         instance2 = get_orchestrator()
@@ -1517,7 +1517,7 @@ async def test_get_chat_client_foundry_mode():
 def test_foundry_not_available():
     """Test when Foundry SDK is not available."""
     # Check that FOUNDRY_AVAILABLE is defined
-    assert hasattr(orch_module, 'FOUNDRY_AVAILABLE')
+    assert hasattr(orchestrator, 'FOUNDRY_AVAILABLE')
 
 # Tests for workflow event handling (lines 736-799, 841-895)
 # Note: These are integration-level tests that verify the workflow event

--- a/src/tests/services/test_orchestrator.py
+++ b/src/tests/services/test_orchestrator.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 import orchestrator
 from orchestrator import (_HARMFUL_PATTERNS_COMPILED,
                           _SYSTEM_PROMPT_PATTERNS_COMPILED,


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request makes minor improvements to the test suite for the `orchestrator` service. The changes focus on updating import statements and references to ensure consistency and clarity in the test code.

* Test code cleanup:
  * Updated import statements and references from `orch_module` to `orchestrator` throughout `src/tests/services/test_orchestrator.py`, improving readability and consistency in test code. [[1]](diffhunk://#diff-a38ddc2f4ba444447f993d02108b53738d72397b1b5ec4c98ba0604c68fca806L6-R6) [[2]](diffhunk://#diff-a38ddc2f4ba444447f993d02108b53738d72397b1b5ec4c98ba0604c68fca806L843-R843) [[3]](diffhunk://#diff-a38ddc2f4ba444447f993d02108b53738d72397b1b5ec4c98ba0604c68fca806L1520-R1520)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [ ] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
