### PR TITLE
fix: added model deployment module for existing AI services

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -547,6 +547,31 @@ module existingAiServicesRoleAssignments 'modules/deploy_foundry_role_assignment
   }
 }
 
+// ========== Model Deployments for Existing AI Services ========== //
+module existingAiServicesModelDeployments 'modules/deploy_ai_model.bicep' = if (useExistingAiFoundryAiProject) {
+  name: take('module.model-deployments-existing.${aiFoundryAiServicesResourceName}', 64)
+  scope: resourceGroup(aiFoundryAiServicesSubscriptionId, aiFoundryAiServicesResourceGroupName)
+  params: {
+    aiServicesName: aiFoundryAiServicesResourceName
+    deployments: [
+      for deployment in aiFoundryAiServicesModelDeployment: {
+        name: deployment.name
+        format: deployment.format
+        model: deployment.model
+        sku: {
+          name: deployment.sku.name
+          capacity: deployment.sku.capacity
+        }
+        version: deployment.version
+        raiPolicyName: deployment.raiPolicyName
+      }
+    ]
+  }
+  dependsOn: [
+    existingAiServicesRoleAssignments
+  ]
+}
+
 // ========== AI Search ========== //
 module aiSearch 'br/public:avm/res/search/search-service:0.12.0' = {
   name: take('avm.res.search.search-service.${aiSearchName}', 64)

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "14392918201193616164"
+      "templateHash": "15389484880957971429"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -14240,6 +14240,100 @@
       },
       "dependsOn": [
         "userAssignedIdentity"
+      ]
+    },
+    "existingAiServicesModelDeployments": {
+      "condition": "[variables('useExistingAiFoundryAiProject')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[take(format('module.model-deployments-existing.{0}', variables('aiFoundryAiServicesResourceName')), 64)]",
+      "subscriptionId": "[variables('aiFoundryAiServicesSubscriptionId')]",
+      "resourceGroup": "[variables('aiFoundryAiServicesResourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "aiServicesName": {
+            "value": "[variables('aiFoundryAiServicesResourceName')]"
+          },
+          "deployments": {
+            "copy": [
+              {
+                "name": "value",
+                "count": "[length(variables('aiFoundryAiServicesModelDeployment'))]",
+                "input": "[createObject('name', variables('aiFoundryAiServicesModelDeployment')[copyIndex('value')].name, 'format', variables('aiFoundryAiServicesModelDeployment')[copyIndex('value')].format, 'model', variables('aiFoundryAiServicesModelDeployment')[copyIndex('value')].model, 'sku', createObject('name', variables('aiFoundryAiServicesModelDeployment')[copyIndex('value')].sku.name, 'capacity', variables('aiFoundryAiServicesModelDeployment')[copyIndex('value')].sku.capacity), 'version', variables('aiFoundryAiServicesModelDeployment')[copyIndex('value')].version, 'raiPolicyName', variables('aiFoundryAiServicesModelDeployment')[copyIndex('value')].raiPolicyName)]"
+              }
+            ]
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.41.2.15936",
+              "templateHash": "12449348145632794739"
+            }
+          },
+          "parameters": {
+            "aiServicesName": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the AI Services account."
+              }
+            },
+            "deployments": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Required. Array of model deployments to create."
+              }
+            }
+          },
+          "resources": [
+            {
+              "copy": {
+                "name": "modelDeployments",
+                "count": "[length(parameters('deployments'))]",
+                "mode": "serial",
+                "batchSize": 1
+              },
+              "type": "Microsoft.CognitiveServices/accounts/deployments",
+              "apiVersion": "2024-10-01",
+              "name": "[format('{0}/{1}', parameters('aiServicesName'), parameters('deployments')[copyIndex()].name)]",
+              "properties": {
+                "model": {
+                  "format": "[parameters('deployments')[copyIndex()].format]",
+                  "name": "[parameters('deployments')[copyIndex()].model]",
+                  "version": "[parameters('deployments')[copyIndex()].version]"
+                },
+                "raiPolicyName": "[parameters('deployments')[copyIndex()].raiPolicyName]"
+              },
+              "sku": {
+                "name": "[parameters('deployments')[copyIndex()].sku.name]",
+                "capacity": "[parameters('deployments')[copyIndex()].sku.capacity]"
+              }
+            }
+          ],
+          "outputs": {
+            "deployedModelNames": {
+              "type": "array",
+              "metadata": {
+                "description": "The names of the deployed models."
+              },
+              "copy": {
+                "count": "[length(parameters('deployments'))]",
+                "input": "[parameters('deployments')[copyIndex()].name]"
+              }
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "existingAiServicesRoleAssignments"
       ]
     },
     "aiSearch": {
@@ -33185,7 +33279,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "4952237836308528733"
+              "templateHash": "11066122245438821615"
             }
           },
           "parameters": {
@@ -33257,9 +33351,8 @@
             },
             "userAssignedIdentityResourceId": {
               "type": "string",
-              "defaultValue": "",
               "metadata": {
-                "description": "Optional. User-assigned managed identity resource ID for ACR pull."
+                "description": "Required. User-assigned managed identity resource ID for ACR pull."
               }
             }
           },

--- a/infra/modules/deploy_ai_model.bicep
+++ b/infra/modules/deploy_ai_model.bicep
@@ -1,0 +1,35 @@
+@description('Required. Name of the AI Services account.')
+param aiServicesName string
+
+@description('Required. Array of model deployments to create.')
+param deployments array = []
+
+// Reference AI Services account (module is scoped to the correct resource group)
+resource aiServices 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' existing = {
+  name: aiServicesName
+}
+
+// Deploy models to AI Services account
+// Using batchSize(1) to avoid concurrent deployment issues
+@batchSize(1)
+resource modelDeployments 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = [
+  for (deployment, index) in deployments: {
+    parent: aiServices
+    name: deployment.name
+    properties: {
+      model: {
+        format: deployment.format
+        name: deployment.model
+        version: deployment.version
+      }
+      raiPolicyName: deployment.raiPolicyName
+    }
+    sku: {
+      name: deployment.sku.name
+      capacity: deployment.sku.capacity
+    }
+  }
+]
+
+@description('The names of the deployed models.')
+output deployedModelNames array = [for (deployment, i) in deployments: modelDeployments[i].name]


### PR DESCRIPTION
## Purpose
This pull request introduces a new module for deploying AI models to existing Azure AI Services accounts, along with the necessary integration into the main infrastructure templates. The changes enable conditional deployment of multiple model deployments to a specified AI Services resource, improving flexibility and modularity in the infrastructure-as-code setup.

Key changes include:

**Model Deployment Module Addition:**

* Added a new Bicep module (`deploy_ai_model.bicep`) that allows deploying an array of models to an existing `Microsoft.CognitiveServices/accounts` resource. The module supports specifying model details, SKU, and Responsible AI policy, and outputs the names of the deployed models.

**Integration with Main Infrastructure:**

* Updated `main.bicep` to conditionally invoke the new model deployment module when using an existing AI Foundry AI project, passing in the required parameters and ensuring dependency on role assignments.
* Extended the generated ARM template (`main.json`) to include the new `existingAiServicesModelDeployments` resource with appropriate parameters, resource group scoping, and dependency configuration.

**Template and Parameter Updates:**

* Updated template hashes in `main.json` to reflect the new module and changes. [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L9-R9) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L33188-R33282)
* Modified the `userAssignedIdentityResourceId` parameter in `main.json` to be required and updated its description for clarity.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.

