### PR TITLE
fix: simplify check for ACI deployment in custom deployment

### DIFF
--- a/azure_custom.yaml
+++ b/azure_custom.yaml
@@ -36,10 +36,7 @@ hooks:
         
         # Check if this is first run (ACR doesn't exist yet)
         # Set IMAGE_TAG='none' to skip ACI deployment until image is built
-        $currentTag = azd env get-value IMAGE_TAG 2>$null
-        $global:LASTEXITCODE = 0
-        
-        if (-not $env:AZURE_CONTAINER_REGISTRY_NAME -and $currentTag -ne 'latest') {
+        if (-not $env:AZURE_CONTAINER_REGISTRY_NAME) {
           Write-Host "First deployment - ACI will be deployed after image build" -ForegroundColor Yellow
           azd env set IMAGE_TAG none
         }
@@ -50,9 +47,7 @@ hooks:
         echo "Preparing deployment..."
         
         # Check if this is first run (ACR doesn't exist yet)
-        current_tag=$(azd env get-value IMAGE_TAG 2>/dev/null || echo "")
-        
-        if [ -z "$AZURE_CONTAINER_REGISTRY_NAME" ] && [ "$current_tag" != "latest" ]; then
+        if [ -z "$AZURE_CONTAINER_REGISTRY_NAME" ]; then
           echo "First deployment - ACI will be deployed after image build"
           azd env set IMAGE_TAG none
         fi


### PR DESCRIPTION
## Purpose
This pull request simplifies the deployment logic in the `azure_custom.yaml` file by removing unnecessary checks when determining if this is the first deployment. The main change is that the script now only checks for the existence of the `AZURE_CONTAINER_REGISTRY_NAME` environment variable, rather than also checking the value of `IMAGE_TAG`.

Deployment script simplification:

* Removed the additional check for `IMAGE_TAG` being not equal to 'latest' in both the PowerShell and Bash deployment hooks, so the script now only checks for the absence of `AZURE_CONTAINER_REGISTRY_NAME` to determine if this is the first deployment. [[1]](diffhunk://#diff-09dca1f3eeb0d08b888401e046f12ffe5293e76db9fca18dfbc4b6a9f5a5fae3L39-R39) [[2]](diffhunk://#diff-09dca1f3eeb0d08b888401e046f12ffe5293e76db9fca18dfbc4b6a9f5a5fae3L53-R50)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.