### PR TITLE
fix: improve error handling for JSON parsing

### DIFF
--- a/infra/scripts/validate_bicep_params.py
+++ b/infra/scripts/validate_bicep_params.py
@@ -108,7 +108,8 @@ def parse_parameters_env_vars(json_path: Path) -> dict[str, list[str]]:
         data = json.loads(sanitized)
         params = data.get("parameters", {})
     except json.JSONDecodeError:
-        pass
+        # Best-effort behavior: if JSON cannot be parsed, treat as no env-var
+        return result
 
     # Walk each top-level parameter and scan its entire serialized value
     # for ${VAR} references from the original text.


### PR DESCRIPTION
## Purpose
This pull request makes a small change to the `parse_parameters_env_vars` function in `infra/scripts/validate_bicep_params.py`. The change improves error handling by ensuring that, if the JSON cannot be parsed, the function returns an empty result instead of failing silently.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
