### PR TITLE
chore: add minimum bicep version >= 0.33.0 to azure_custom.yaml

### DIFF
--- a/azure_custom.yaml
+++ b/azure_custom.yaml
@@ -4,6 +4,7 @@ metadata:
 
 requiredVersions:
   azd: '>= 1.18.0 != 1.23.9'
+  bicep: '>= 0.33.0'
 
 infra:
   path: ./infra


### PR DESCRIPTION
## Summary
Adds bicep >= 0.33.0 to requiredVersions in azure_custom.yaml to enforce minimum Bicep CLI version.

## Changes
- Updated azure_custom.yaml to include bicep: >= 0.33.0 under requiredVersions