### PR TITLE
feat: Add pytest coverage comment to PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   contents: read
   actions: read
+  pull-requests: write
 
 concurrency:
   group: test-${{ github.ref }}
@@ -69,7 +70,19 @@ jobs:
       - name: Run Backend Tests with Coverage
         if: env.skip_backend_tests == 'false'
         run: |
-          pytest --cov=. --cov-report=term-missing --cov-report=xml ./src/tests
+          pytest --cov=. --cov-report=term-missing --cov-report=xml --junitxml=pytest.xml ./src/tests
+
+      - name: Pytest Coverage Comment
+        if: |
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          env.skip_backend_tests == 'false'
+        uses: MishaKav/pytest-coverage-comment@26f986d2599c288bb62f623d29c2da98609e9cd4  # v1.6.0
+        with:
+          pytest-xml-coverage-path: coverage.xml
+          junitxml-path: pytest.xml
+          report-only-changed-files: true
 
       - name: Skip Backend Tests
         if: env.skip_backend_tests == 'true'


### PR DESCRIPTION
Add MishaKav/pytest-coverage-comment action to post code coverage summary as a PR comment. Changes include:
- Add pull-requests: write permission
- Add --junitxml=pytest.xml flag for test summary
- Add coverage comment step with per-file breakdown

## Purpose

This pull request updates the GitHub Actions workflow to improve test reporting for pull requests. The main changes are the addition of automated coverage comments on pull requests and updates to permissions to support this feature.

**CI workflow improvements:**

* Added `pull-requests: write` permission to the workflow to allow posting comments on pull requests.
* Added a new step to run the `MishaKav/pytest-coverage-comment` GitHub Action, which posts test coverage summaries as comments on pull requests. This step is conditionally executed only for non-fork pull requests and when backend tests are not skipped.
* Updated the pytest command to generate a `junitxml` report (`pytest.xml`), which is required as input for the coverage comment action.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

