### PR TITLE
fix: removed the bicep parameter

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,7 +8,6 @@ metadata:
 
 requiredVersions:
   azd: '>= 1.18.0 != 1.23.9'
-  bicep: '>= 0.33.0'
 
 parameters:
   solutionPrefix:


### PR DESCRIPTION
## Purpose
Removed `bicep: '>= 0.33.0'` from the `requiredVersions` section in `azure.yaml`.

Related work items: AB#40862

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.