### PR TITLE
fix: add content-type check for non-JSON responses in fetchExternal

### DIFF
--- a/src/App/src/utils/httpClient.ts
+++ b/src/App/src/utils/httpClient.ts
@@ -68,6 +68,10 @@ class HttpClient {
     if (!response.ok) {
       throw new Error(`${config.method || 'GET'} ${url} failed: ${response.statusText}`);
     }
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+      throw new Error(`${config.method || 'GET'} ${url} returned non-JSON response (${contentType})`);
+    }
     return response.json();
   }
 }

--- a/src/App/src/utils/httpClient.ts
+++ b/src/App/src/utils/httpClient.ts
@@ -70,7 +70,7 @@ class HttpClient {
     }
     const contentType = response.headers.get('content-type') || '';
     if (!contentType.includes('application/json')) {
-      throw new Error(`${config.method || 'GET'} ${url} returned non-JSON response (${contentType})`);
+      throw new Error(`${config.method || 'GET'} ${url} returned non-JSON response`);
     }
     return response.json();
   }


### PR DESCRIPTION
## Purpose
This pull request adds stricter response validation to the `HttpClient` utility by ensuring that all HTTP responses are JSON before attempting to parse them. This helps prevent runtime errors and improves error handling.

**Improvements to error handling:**

* [`src/App/src/utils/httpClient.ts`](diffhunk://#diff-525b275410409332118a473cfb41cffec2c6d1d57f6bd17554f50aabb18e1d71R71-R74): Added a check to verify that the `content-type` header includes `application/json` before parsing the response, and throw a descriptive error if not.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.