### PR TITLE
fix: add content-type check for non-JSON responses in HttpClient

### DIFF
--- a/src/App/src/utils/httpClient.ts
+++ b/src/App/src/utils/httpClient.ts
@@ -70,7 +70,7 @@ class HttpClient {
     }
     const contentType = response.headers.get('content-type') || '';
     if (!contentType.toLowerCase().includes('application/json')) {
-      throw new Error(`${config.method || 'GET'} ${url} returned non-JSON response`);
+      throw new Error(`${config.method || 'GET'} ${url} returned non-JSON response (content-type: ${contentType || 'unknown'})`);
     }
     return response.json();
   }

--- a/src/App/src/utils/httpClient.ts
+++ b/src/App/src/utils/httpClient.ts
@@ -68,6 +68,10 @@ class HttpClient {
     if (!response.ok) {
       throw new Error(`${config.method || 'GET'} ${url} failed: ${response.statusText}`);
     }
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.toLowerCase().includes('application/json')) {
+      throw new Error(`${config.method || 'GET'} ${url} returned non-JSON response`);
+    }
     return response.json();
   }
 }


### PR DESCRIPTION
## Purpose
This pull request adds an extra validation step to the `HttpClient` utility to ensure that all HTTP responses are in JSON format before attempting to parse them. This helps prevent runtime errors when the server returns unexpected content types.

Error handling improvements:

* Added a check in `HttpClient` (`src/App/src/utils/httpClient.ts`) to verify that the response's `Content-Type` header includes `application/json`, throwing an error if a non-JSON response is received.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.
