### PR TITLE
fix: Configure API proxy with dynamic BACKEND_URL

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -914,13 +914,11 @@ module webServerFarm 'br/public:avm/res/web/serverfarm:0.7.0' = {
 
 // ========== Web App ========== //
 var webSiteResourceName = 'app-${solutionSuffix}'
-// Backend URL: Use ACI IP (private or public) or FQDN depending on networking mode
-var aciPrivateIpFallback = '10.0.4.4'
-var aciPublicFqdnFallback = '${containerInstanceName}.${solutionLocation}.azurecontainer.io'
-// For private networking use IP, for public use FQDN
+// Backend URL: Use actual ACI IP/FQDN from deployment outputs
+// This also creates an implicit dependency ensuring ACI deploys before the web app
 var aciBackendUrl = enablePrivateNetworking
-  ? 'http://${aciPrivateIpFallback}:8000'
-  : 'http://${aciPublicFqdnFallback}:8000'
+  ? 'http://${containerInstance.outputs.ipAddress}:8000'
+  : 'http://${containerInstance.outputs.fqdn}:8000'
 module webSite 'modules/web-sites.bicep' = {
   name: take('module.web-sites.${webSiteResourceName}', 64)
   params: {

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "12441959736083561218"
+      "templateHash": "9315041614692254935"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -383,9 +383,6 @@
     "cosmosDBProductsContainer": "products",
     "webServerFarmResourceName": "[format('asp-{0}', variables('solutionSuffix'))]",
     "webSiteResourceName": "[format('app-{0}', variables('solutionSuffix'))]",
-    "aciPrivateIpFallback": "10.0.4.4",
-    "aciPublicFqdnFallback": "[format('{0}.{1}.azurecontainer.io', variables('containerInstanceName'), variables('solutionLocation'))]",
-    "aciBackendUrl": "[if(parameters('enablePrivateNetworking'), format('http://{0}:8000', variables('aciPrivateIpFallback')), format('http://{0}:8000', variables('aciPublicFqdnFallback')))]",
     "containerInstanceName": "[format('aci-{0}', variables('solutionSuffix'))]"
   },
   "resources": {
@@ -24915,8 +24912,8 @@
       },
       "dependsOn": [
         "aiFoundryAiServices",
-        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').cognitiveServices)]",
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').openAI)]",
         "virtualNetwork"
       ]
     },
@@ -42336,7 +42333,7 @@
           },
           "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webSubnetResourceId.value), createObject('value', null()))]",
           "configs": {
-            "value": "[concat(createArray(createObject('name', 'appsettings', 'properties', createObject('DOCKER_REGISTRY_SERVER_URL', format('https://{0}.azurecr.io', variables('acrResourceName')), 'BACKEND_URL', variables('aciBackendUrl'), 'AZURE_CLIENT_ID', reference('userAssignedIdentity').outputs.clientId.value), 'applicationInsightResourceId', if(parameters('enableMonitoring'), reference('applicationInsights').outputs.resourceId.value, null()))), if(parameters('enableMonitoring'), createArray(createObject('name', 'logs', 'properties', createObject())), createArray()))]"
+            "value": "[concat(createArray(createObject('name', 'appsettings', 'properties', createObject('DOCKER_REGISTRY_SERVER_URL', format('https://{0}.azurecr.io', variables('acrResourceName')), 'BACKEND_URL', if(parameters('enablePrivateNetworking'), format('http://{0}:8000', reference('containerInstance').outputs.ipAddress.value), format('http://{0}:8000', reference('containerInstance').outputs.fqdn.value)), 'AZURE_CLIENT_ID', reference('userAssignedIdentity').outputs.clientId.value), 'applicationInsightResourceId', if(parameters('enableMonitoring'), reference('applicationInsights').outputs.resourceId.value, null()))), if(parameters('enableMonitoring'), createArray(createObject('name', 'logs', 'properties', createObject())), createArray()))]"
           },
           "enableMonitoring": {
             "value": "[parameters('enableMonitoring')]"
@@ -42363,7 +42360,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "18300393946144087310"
+              "templateHash": "10464081739325272474"
             }
           },
           "definitions": {
@@ -43402,7 +43399,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.42.1.51946",
-                      "templateHash": "1934732677721164061"
+                      "templateHash": "904290865426801162"
                     },
                     "name": "Site App Settings",
                     "description": "This module deploys a Site App Setting."
@@ -43515,7 +43512,7 @@
                       "type": "Microsoft.Web/sites/config",
                       "apiVersion": "2025-03-01",
                       "name": "[format('{0}/{1}', parameters('appName'), parameters('name'))]",
-                      "properties": "[union(parameters('properties'), parameters('currentAppSettings'), if(and(not(empty(parameters('storageAccountResourceId'))), not(parameters('storageAccountUseIdentityAuthentication'))), createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}', last(split(parameters('storageAccountResourceId'), '/')), listKeys('storageAccount', '2025-08-01').keys[0].value, environment().suffixes.storage)), if(and(not(empty(parameters('storageAccountResourceId'))), parameters('storageAccountUseIdentityAuthentication')), createObject('AzureWebJobsStorage__accountName', last(split(parameters('storageAccountResourceId'), '/')), 'AzureWebJobsStorage__blobServiceUri', reference('storageAccount').primaryEndpoints.blob, 'AzureWebJobsStorage__queueServiceUri', reference('storageAccount').primaryEndpoints.queue, 'AzureWebJobsStorage__tableServiceUri', reference('storageAccount').primaryEndpoints.table), createObject())), if(not(empty(parameters('applicationInsightResourceId'))), createObject('APPLICATIONINSIGHTS_CONNECTION_STRING', reference('applicationInsights').ConnectionString), createObject()), variables('loggingProperties'))]",
+                      "properties": "[union(parameters('currentAppSettings'), parameters('properties'), if(and(not(empty(parameters('storageAccountResourceId'))), not(parameters('storageAccountUseIdentityAuthentication'))), createObject('AzureWebJobsStorage', format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}', last(split(parameters('storageAccountResourceId'), '/')), listKeys('storageAccount', '2025-08-01').keys[0].value, environment().suffixes.storage)), if(and(not(empty(parameters('storageAccountResourceId'))), parameters('storageAccountUseIdentityAuthentication')), createObject('AzureWebJobsStorage__accountName', last(split(parameters('storageAccountResourceId'), '/')), 'AzureWebJobsStorage__blobServiceUri', reference('storageAccount').primaryEndpoints.blob, 'AzureWebJobsStorage__queueServiceUri', reference('storageAccount').primaryEndpoints.queue, 'AzureWebJobsStorage__tableServiceUri', reference('storageAccount').primaryEndpoints.table), createObject())), if(not(empty(parameters('applicationInsightResourceId'))), createObject('APPLICATIONINSIGHTS_CONNECTION_STRING', reference('applicationInsights').ConnectionString), createObject()), variables('loggingProperties'))]",
                       "dependsOn": [
                         "applicationInsights",
                         "storageAccount"
@@ -44286,6 +44283,7 @@
       },
       "dependsOn": [
         "applicationInsights",
+        "containerInstance",
         "logAnalyticsWorkspace",
         "userAssignedIdentity",
         "virtualNetwork",

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -947,13 +947,11 @@ module webServerFarm 'br/public:avm/res/web/serverfarm:0.7.0' = {
 
 // ========== Web App ========== //
 var webSiteResourceName = 'app-${solutionSuffix}'
-// Backend URL: Use ACI IP (private or public) or FQDN depending on networking mode
-var aciPrivateIpFallback = '10.0.4.4'
-var aciPublicFqdnFallback = '${containerInstanceName}.${solutionLocation}.azurecontainer.io'
-// For private networking use IP, for public use FQDN
+// Backend URL: Use actual ACI IP/FQDN from deployment outputs
+// This also creates an implicit dependency ensuring ACI deploys before the web app
 var aciBackendUrl = enablePrivateNetworking
-  ? 'http://${aciPrivateIpFallback}:8000'
-  : 'http://${aciPublicFqdnFallback}:8000'
+  ? 'http://${shouldDeployACI ? containerInstance!.properties.ipAddress.ip : ''}:8000'
+  : 'http://${shouldDeployACI ? containerInstance!.properties.ipAddress.fqdn : ''}:8000'
 module webSite 'modules/web-sites.bicep' = {
   name: take('module.web-sites.${webSiteResourceName}', 64)
   params: {

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -949,9 +949,11 @@ module webServerFarm 'br/public:avm/res/web/serverfarm:0.7.0' = {
 var webSiteResourceName = 'app-${solutionSuffix}'
 // Backend URL: Use actual ACI IP/FQDN from deployment outputs
 // This also creates an implicit dependency ensuring ACI deploys before the web app
-var aciBackendUrl = enablePrivateNetworking
-  ? 'http://${shouldDeployACI ? containerInstance!.properties.ipAddress.ip : ''}:8000'
-  : 'http://${shouldDeployACI ? containerInstance!.properties.ipAddress.fqdn : ''}:8000'
+var aciBackendUrl = shouldDeployACI
+  ? (enablePrivateNetworking
+    ? 'http://${containerInstance!.properties.ipAddress.ip}:8000'
+    : 'http://${containerInstance!.properties.ipAddress.fqdn}:8000')
+  : ''
 module webSite 'modules/web-sites.bicep' = {
   name: take('module.web-sites.${webSiteResourceName}', 64)
   params: {

--- a/infra/modules/web-sites.config.bicep
+++ b/infra/modules/web-sites.config.bicep
@@ -84,8 +84,8 @@ var loggingProperties = enableMonitoring && name == 'logs'
   : {}
 
 var expandedProperties = union(
-  properties,
   currentAppSettings,
+  properties,
   azureWebJobsValues,
   appInsightsValues,
   loggingProperties

--- a/src/App/server/server.js
+++ b/src/App/server/server.js
@@ -67,7 +67,9 @@ app.get('/{*path}', (req, res) => {
 // Create server with extended timeouts for SSE
 const server = app.listen(PORT, () => {
     console.log(`Frontend server running on port ${PORT}`);
-    console.log(`Proxying API requests to ${BACKEND_URL}`);
+    if (BACKEND_URL) {
+        console.log(`Proxying API requests to ${BACKEND_URL}`);
+    }
 });
 
 // Extend server timeouts for long-running SSE connections

--- a/src/App/server/server.js
+++ b/src/App/server/server.js
@@ -21,7 +21,8 @@ const httpAgent = new http.Agent({
 });
 
 // Proxy API requests to backend
-app.use('/api', createProxyMiddleware({
+if (BACKEND_URL) {
+    app.use('/api', createProxyMiddleware({
     target: BACKEND_URL,
     changeOrigin: true,
     pathRewrite: {
@@ -54,7 +55,7 @@ app.use('/api', createProxyMiddleware({
         }
     }
 }));
-
+}
 // Serve static files from the build directory
 app.use(express.static(path.join(__dirname, 'static')));
 

--- a/src/App/server/server.js
+++ b/src/App/server/server.js
@@ -6,8 +6,11 @@ const http = require('http');
 const app = express();
 const PORT = process.env.PORT || 8080;
 
-// Backend API URL (ACI private IP in VNet)
-const BACKEND_URL = process.env.BACKEND_URL || 'http://10.0.4.5:8000';
+// Backend API URL (injected via BACKEND_URL env var at deployment time)
+if (!process.env.BACKEND_URL) {
+    console.error('ERROR: BACKEND_URL environment variable is not set. API proxy will not work.');
+}
+const BACKEND_URL = process.env.BACKEND_URL;
 
 // Create HTTP agent with extended keep-alive timeout for long-running SSE connections
 const httpAgent = new http.Agent({


### PR DESCRIPTION
## Purpose
This pull request updates how the backend API URL for the web application is determined and injected, ensuring that the web app always connects to the correct backend container instance (ACI) endpoint based on deployment outputs instead of hardcoded or fallback values. It also improves deployment dependencies and environment variable handling for both infrastructure and application code.

**Key changes:**

Backend URL resolution and dependency improvements:
- The web app's backend URL (`aciBackendUrl`) is now dynamically set using the actual output IP or FQDN from the container instance deployment, ensuring the web app always points to the correct backend endpoint and that the web app deployment waits for the container instance to be ready (`infra/main.bicep`, `infra/main_custom.bicep`). [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L917-R921) [[2]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L950-R954)
- Removed legacy fallback variables and logic for backend URL construction from the ARM template, further enforcing use of deployment outputs (`infra/main.json`). [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L386-L388) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L42339-R42336)
- Updated app settings injection to use the resolved backend URL from the container instance outputs, not static values (`infra/main.json`).

Deployment and dependency ordering:
- Fixed and clarified resource dependency ordering in the ARM template to ensure resources like private DNS zones and the container instance are provisioned before dependent resources (`infra/main.json`). [[1]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L24918-R24916) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R44286)

Application code improvements:
- The Node.js server now requires the `BACKEND_URL` environment variable to be set at runtime, removing any hardcoded fallback, and logs an error if it is missing. The proxy middleware is only enabled if `BACKEND_URL` is set (`src/App/server/server.js`). [[1]](diffhunk://#diff-4c9f3345bafb396d8da7d50cc8c446fd60a030624a883ca6fbb9aec5c52ff1ccL9-R13) [[2]](diffhunk://#diff-4c9f3345bafb396d8da7d50cc8c446fd60a030624a883ca6fbb9aec5c52ff1ccR24) [[3]](diffhunk://#diff-4c9f3345bafb396d8da7d50cc8c446fd60a030624a883ca6fbb9aec5c52ff1ccL54-R58)

App settings merge logic:
- In `web-sites.config.bicep`, the merge order for application settings was adjusted to ensure that current app settings are merged before new properties, which can affect override behavior (`infra/modules/web-sites.config.bicep`).

These changes together ensure that the backend URL is always accurate, deployment dependencies are respected, and the application behaves correctly in all deployment scenarios.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.