### PR TITLE
fix: SFI issue fixes

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -494,6 +494,7 @@ module jumpboxVM 'br/public:avm/res/compute/virtual-machine:0.21.0' = if (deploy
 
 // ========== Data Collection Rule for Jumpbox Security Event Logs (SFI-AzTBv17) ========== //
 var jumpboxDcrName = take('dcr-${jumpboxVmName}', 64)
+var dcrLogAnalyticsDestinationName = 'la-${logAnalyticsWorkspaceResourceName}-destination'
 module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if (deployAdminAccessResources && enableMonitoring) {
   name: take('avm.res.insights.data-collection-rule.${jumpboxDcrName}', 64)
   params: {
@@ -512,7 +513,7 @@ module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if 
               'Microsoft-SecurityEvent'
             ]
             xPathQueries: [
-              'Security!*[System[(band(Keywords,13510798882111488))]]'
+              'Security!*[System[(band(Keywords,13510798882111488)) and (EventID != 4624)]]'
             ]
           }
         ]
@@ -520,7 +521,7 @@ module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if 
       destinations: {
         logAnalytics: [
           {
-            name: 'laDestination'
+            name: dcrLogAnalyticsDestinationName
             workspaceResourceId: logAnalyticsWorkspaceResourceId
           }
         ]
@@ -531,7 +532,7 @@ module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if 
             'Microsoft-SecurityEvent'
           ]
           destinations: [
-            'laDestination'
+            dcrLogAnalyticsDestinationName
           ]
         }
       ]

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "14282475649019624593"
+      "templateHash": "11476101976733556609"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -354,6 +354,7 @@
     "jumpboxUniqueToken": "[take(uniqueString(resourceGroup().id, variables('solutionSuffix')), 10)]",
     "jumpboxVmName": "[take(format('vm-{0}', variables('jumpboxUniqueToken')), 15)]",
     "jumpboxDcrName": "[take(format('dcr-{0}', variables('jumpboxVmName')), 64)]",
+    "dcrLogAnalyticsDestinationName": "[format('la-{0}-destination', variables('logAnalyticsWorkspaceResourceName'))]",
     "privateDnsZones": [
       "privatelink.cognitiveservices.azure.com",
       "privatelink.openai.azure.com",
@@ -18302,7 +18303,7 @@
                       "Microsoft-SecurityEvent"
                     ],
                     "xPathQueries": [
-                      "Security!*[System[(band(Keywords,13510798882111488))]]"
+                      "Security!*[System[(band(Keywords,13510798882111488)) and (EventID != 4624)]]"
                     ]
                   }
                 ]
@@ -18310,7 +18311,7 @@
               "destinations": {
                 "logAnalytics": [
                   {
-                    "name": "laDestination",
+                    "name": "[variables('dcrLogAnalyticsDestinationName')]",
                     "workspaceResourceId": "[if(variables('useExistingLogAnalytics'), parameters('existingLogAnalyticsWorkspaceId'), if(parameters('enableMonitoring'), reference('logAnalyticsWorkspace').outputs.resourceId.value, ''))]"
                   }
                 ]
@@ -18321,7 +18322,7 @@
                     "Microsoft-SecurityEvent"
                   ],
                   "destinations": [
-                    "laDestination"
+                    "[variables('dcrLogAnalyticsDestinationName')]"
                   ]
                 }
               ]

--- a/infra/main_custom.bicep
+++ b/infra/main_custom.bicep
@@ -520,6 +520,7 @@ module jumpboxVM 'br/public:avm/res/compute/virtual-machine:0.21.0' = if (deploy
 
 // ========== Data Collection Rule for Jumpbox Security Event Logs (SFI-AzTBv17) ========== //
 var jumpboxDcrName = take('dcr-${jumpboxVmName}', 64)
+var dcrLogAnalyticsDestinationName = 'la-${logAnalyticsWorkspaceResourceName}-destination'
 module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if (deployAdminAccessResources && enableMonitoring) {
   name: take('avm.res.insights.data-collection-rule.${jumpboxDcrName}', 64)
   params: {
@@ -538,7 +539,7 @@ module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if 
               'Microsoft-SecurityEvent'
             ]
             xPathQueries: [
-              'Security!*[System[(band(Keywords,13510798882111488))]]'
+              'Security!*[System[(band(Keywords,13510798882111488)) and (EventID != 4624)]]'
             ]
           }
         ]
@@ -546,7 +547,7 @@ module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if 
       destinations: {
         logAnalytics: [
           {
-            name: 'laDestination'
+            name: dcrLogAnalyticsDestinationName
             workspaceResourceId: logAnalyticsWorkspaceResourceId
           }
         ]
@@ -557,7 +558,7 @@ module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if 
             'Microsoft-SecurityEvent'
           ]
           destinations: [
-            'laDestination'
+            dcrLogAnalyticsDestinationName
           ]
         }
       ]


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This pull request updates the data collection rules and destination naming for Jumpbox security event logs. The main goals are to filter out certain event types from log collection and to standardize the naming of Log Analytics destinations. These changes are applied consistently across both Bicep (`infra/main.bicep`, `infra/main_custom.bicep`) and the generated ARM template (`infra/main.json`).

**Event log filtering improvements:**

- Updated the `xPathQueries` for security event log collection to exclude events with `EventID` 4624, reducing noise by ignoring successful logon events. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L515-R524) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L18305-R18314) [[3]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L541-R550)

**Log Analytics destination standardization:**

- Introduced a variable (`dcrLogAnalyticsDestinationName`) to generate a consistent and descriptive name for Log Analytics destinations, replacing the previous hardcoded `'laDestination'` value. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R497) [[2]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4R357) [[3]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62R523)
- Updated all references to the Log Analytics destination in both the data collection rule and its associations to use the new variable instead of the old hardcoded name. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L515-R524) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L534-R535) [[3]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L18305-R18314) [[4]](diffhunk://#diff-0504f5a35afecd5c8c2a1dc8cac5bb558cc1456c557d8edcb7f9bac1c0dc36e4L18324-R18325) [[5]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L541-R550) [[6]](diffhunk://#diff-6f5772bf1f1d80cc16f30c80915d9e5622ad0637daf5b5dff29308ad5fc68b62L560-R561)

**Template consistency:**

- Regenerated the ARM template (`infra/main.json`) to reflect the above changes, including the updated `templateHash`.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## Golden Path Validation
- [ ] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [ ] I have validated the deployment process successfully and all services are running as expected with this change.

## What to Check
Verify that the following are valid
* ...

## Other Information

<!-- Add any other helpful information that may be needed here. -->
