### PR TITLE
fix: update custom token provider functions for copilot review

### DIFF
--- a/src/backend/orchestrator.py
+++ b/src/backend/orchestrator.py
@@ -124,8 +124,8 @@ SYSTEM_PROMPT_PATTERNS = [
     r"You are an Image Content Agent",
     r"You are a Compliance Agent",
     # Handoff instructions (match both underscore and hyphen agent names)
-    r"hand off to \w+[_\-]agent",
-    r"hand back to \w+[_\-]agent",
+    r"hand off to [\w\-]+[_\-]agent",
+    r"hand back to [\w\-]+[_\-]agent",
     r"may hand off to",
     r"After (?:generating|completing|validation|parsing)",
     # Internal workflow markers
@@ -545,11 +545,6 @@ class ContentGenerationOrchestrator:
                 if not azure_endpoint:
                     raise ValueError("AZURE_OPENAI_ENDPOINT is required for Foundry mode chat completions")
 
-                def get_token() -> str:
-                    """Token provider callable - invoked for each request to ensure fresh tokens."""
-                    token = self._credential.get_token(TOKEN_ENDPOINT)
-                    return token.token
-
                 model_deployment = app_settings.ai_foundry.model_deployment or app_settings.azure_openai.gpt_model
                 api_version = app_settings.azure_openai.api_version
 
@@ -558,7 +553,7 @@ class ContentGenerationOrchestrator:
                     azure_endpoint=azure_endpoint,
                     model=model_deployment,
                     api_version=api_version,
-                    credential=get_token,
+                    credential=self._credential,
                 )
             else:
                 # Azure OpenAI Direct mode
@@ -566,17 +561,12 @@ class ContentGenerationOrchestrator:
                 if not endpoint:
                     raise ValueError("AZURE_OPENAI_ENDPOINT is not configured")
 
-                def get_token() -> str:
-                    """Token provider callable - invoked for each request to ensure fresh tokens."""
-                    token = self._credential.get_token(TOKEN_ENDPOINT)
-                    return token.token
-
-                logger.info("Using Azure OpenAI Direct mode with DefaultAzureCredential token provider")
+                logger.info("Using Azure OpenAI Direct mode with DefaultAzureCredential")
                 self._chat_client = OpenAIChatCompletionClient(
                     azure_endpoint=endpoint,
                     model=app_settings.azure_openai.gpt_model,
                     api_version=app_settings.azure_openai.api_version,
-                    credential=get_token,
+                    credential=self._credential,
                 )
         return self._chat_client
 

--- a/src/backend/services/title_service.py
+++ b/src/backend/services/title_service.py
@@ -17,9 +17,6 @@ from settings import app_settings
 
 logger = logging.getLogger(__name__)
 
-# Token endpoint for Azure OpenAI authentication
-TOKEN_ENDPOINT = "https://cognitiveservices.azure.com/.default"
-
 # Title generation instructions (from MS reference accelerator)
 TITLE_INSTRUCTIONS = """Summarize the conversation so far into a 4-word or less title.
 Do not use any quotation marks or punctuation.
@@ -58,17 +55,11 @@ class TitleService:
 
             api_version = app_settings.azure_openai.api_version
 
-            # Create token provider function
-            def get_token() -> str:
-                """Token provider callable - invoked for each request to ensure fresh tokens."""
-                token = self._credential.get_token(TOKEN_ENDPOINT)
-                return token.token
-
             chat_client = OpenAIChatCompletionClient(
                 azure_endpoint=endpoint,
                 model=deployment,
                 api_version=api_version,
-                credential=get_token,
+                credential=self._credential,
             )
 
             self._agent = Agent(

--- a/src/tests/services/test_orchestrator.py
+++ b/src/tests/services/test_orchestrator.py
@@ -135,6 +135,24 @@ def test_filter_system_prompt_handoff():
     assert "text_content_agent" not in filtered
 
 
+def test_filter_system_prompt_handoff_hyphenated():
+    """Test filtering of handoff instructions with hyphenated agent names."""
+
+    response = "I'll hand off to text-content-agent now"
+    filtered = _filter_system_prompt_from_response(response)
+
+    assert "text-content-agent" not in filtered
+
+
+def test_filter_system_prompt_handback_hyphenated():
+    """Test filtering of hand back instructions with hyphenated agent names."""
+
+    response = "Let me hand back to triage-agent with results"
+    filtered = _filter_system_prompt_from_response(response)
+
+    assert "triage-agent" not in filtered
+
+
 def test_filter_system_prompt_critical():
     """Test filtering of critical instruction markers."""
 

--- a/src/tests/test_title_generation_service.py
+++ b/src/tests/test_title_generation_service.py
@@ -178,3 +178,67 @@ class TestGetTitleServiceSingleton:
         mock_existing.__bool__ = lambda self: True
         result = get_title_service()
         assert result is mock_existing
+
+
+# ---------------------------------------------------------------------------
+# TitleService.initialize wiring
+# ---------------------------------------------------------------------------
+
+
+class TestTitleServiceInitialize:
+    """Tests that initialize wires the chat client with correct config."""
+
+    @patch("services.title_service.app_settings")
+    @patch("services.title_service.DefaultAzureCredential")
+    @patch("services.title_service.OpenAIChatCompletionClient")
+    @patch("services.title_service.Agent")
+    def test_initialize_wires_credential_direct_mode(
+        self, mock_agent, mock_client, mock_cred_cls, mock_settings
+    ):
+        """Test that initialize passes credential directly to chat client."""
+        mock_credential = MagicMock()
+        mock_cred_cls.return_value = mock_credential
+
+        mock_settings.ai_foundry.use_foundry = False
+        mock_settings.azure_openai.endpoint = "https://test.openai.azure.com"
+        mock_settings.azure_openai.gpt_model = "gpt-4o"
+        mock_settings.azure_openai.api_version = "2024-02-15"
+
+        svc = TitleService()
+        svc.initialize()
+
+        mock_client.assert_called_once_with(
+            azure_endpoint="https://test.openai.azure.com",
+            model="gpt-4o",
+            api_version="2024-02-15",
+            credential=mock_credential,
+        )
+        assert svc._initialized is True
+
+    @patch("services.title_service.app_settings")
+    @patch("services.title_service.DefaultAzureCredential")
+    @patch("services.title_service.OpenAIChatCompletionClient")
+    @patch("services.title_service.Agent")
+    def test_initialize_wires_credential_foundry_mode(
+        self, mock_agent, mock_client, mock_cred_cls, mock_settings
+    ):
+        """Test that initialize uses Foundry endpoint and model."""
+        mock_credential = MagicMock()
+        mock_cred_cls.return_value = mock_credential
+
+        mock_settings.ai_foundry.use_foundry = True
+        mock_settings.azure_openai.endpoint = "https://foundry.openai.azure.com"
+        mock_settings.ai_foundry.model_deployment = "gpt-4o-foundry"
+        mock_settings.azure_openai.gpt_model = "gpt-4o"
+        mock_settings.azure_openai.api_version = "2024-02-15"
+
+        svc = TitleService()
+        svc.initialize()
+
+        mock_client.assert_called_once_with(
+            azure_endpoint="https://foundry.openai.azure.com",
+            model="gpt-4o-foundry",
+            api_version="2024-02-15",
+            credential=mock_credential,
+        )
+        assert svc._initialized is True


### PR DESCRIPTION
## Purpose
This pull request simplifies authentication handling for Azure OpenAI clients by removing custom token provider functions and passing the credential object directly. It also includes a minor update to a regular expression for improved agent handoff detection.

**Authentication handling improvements:**

* Replaced custom `get_token` provider functions with direct use of `self._credential` when initializing `OpenAIChatCompletionClient` in both `orchestrator.py` and `title_service.py`, reducing code duplication and improving maintainability. 
* Removed the now-unnecessary `TOKEN_ENDPOINT` constant from `title_service.py`.

**Regex update:**

* Updated the agent handoff detection regex in `_check_input_for_harmful_content` to better match agent names containing hyphens, improving pattern coverage.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [X] No


## Golden Path Validation
- [X] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [X] I have validated the deployment process successfully and all services are running as expected with this change.


## Other Information

This pull request refactors how Azure OpenAI authentication credentials are provided to the chat client across the codebase. The main change is to pass the credential object directly instead of a token-providing function, simplifying authentication logic and reducing code duplication. Additionally, an unused constant is removed, and some regular expressions are slightly adjusted.

**Azure OpenAI Authentication Refactor:**

* Replaces the use of custom `get_token` functions with direct passing of the credential object (`self._credential`) to `OpenAIChatCompletionClient` in both orchestrator and title service modules. This simplifies the authentication flow and reduces redundant code. 
* Removes the `TOKEN_ENDPOINT` constant from `src/backend/services/title_service.py` as it is no longer needed after refactoring.
* Updates log messages to reflect the new authentication approach, removing references to the token provider function.

**Regular Expression Update:**

* Adjusts regular expressions in `_check_input_for_harmful_content` to better match agent handoff instructions by expanding the character class for agent names.