### PR TITLE
chore: update CODEOWNERS handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @Avijit-Microsoft @Roopan-Microsoft @Prajwal-Microsoft @aniaroramsft @Vinay-Microsoft @malrose07 @toherman-msft @nchandhi
+* @Avijit-Microsoft @Roopan-Microsoft @Prajwal1-Microsoft @aniaroramsft @VinaySh-Microsoft @malrose07 @toherman-msft @nchandhi


### PR DESCRIPTION
## Purpose
* Update CODEOWNERS to replace two GitHub handles with their current accounts.
  * `@Vinay-Microsoft` -> `@VinaySh-Microsoft`
  * `@Prajwal-Microsoft` -> `@Prajwal1-Microsoft`

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Golden Path Validation
- [x] No code paths affected; ownership metadata only.

## Deployment Validation
- [x] N/A — no deployment impact.

## What to Check
* `.github/CODEOWNERS` references the correct, active accounts.

## Other Information
Handle-only update; no functional changes.