### PR TITLE
feat: Implement ACR deployment and update infrastructure scripts

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -55,98 +55,30 @@ hooks:
   postprovision:
     windows:
       run: |
-        Write-Host "===== Provision Complete =====" -ForegroundColor Green
-        Write-Host ""
-        Write-Host "Web App URL: " -NoNewline
-        Write-Host "$env:WEB_APP_URL" -ForegroundColor Cyan
-        Write-Host "Storage Account: " -NoNewline
-        Write-Host "$env:AZURE_BLOB_ACCOUNT_NAME" -ForegroundColor Cyan
-        Write-Host "AI Search Service: " -NoNewline
-        Write-Host "$env:AI_SEARCH_SERVICE_NAME" -ForegroundColor Cyan
-        Write-Host "AI Search Index: " -NoNewline
-        Write-Host "$env:AZURE_AI_SEARCH_PRODUCTS_INDEX" -ForegroundColor Cyan
-        Write-Host "AI Service Location: " -NoNewline
-        Write-Host "$env:AZURE_ENV_AI_SERVICE_LOCATION" -ForegroundColor Cyan
-        Write-Host "Container Instance: " -NoNewline
-        Write-Host "$env:CONTAINER_INSTANCE_NAME" -ForegroundColor Cyan     
-        
-        # Run post-deploy script to upload sample data and create search index
-        Write-Host ""
-        # Note: Cosmos DB role is assigned to deployer via Bicep.
-        Write-Host "===== Running Post-Deploy Script =====" -ForegroundColor Yellow
-        Write-Host "This will upload sample data and create the search index..."
+        Write-Host "===== Provisioning Complete =====" -ForegroundColor Green
+        Write-Host "Run the following two scripts, in order:" -ForegroundColor Yellow
+        Write-Host "  1. Build and push the application images to ACR, then update the web app and container instance:" -ForegroundColor Yellow
+        Write-Host "     ./infra/scripts/build_and_deploy_images.ps1" -ForegroundColor Cyan
+        Write-Host "  2. Load the sample data into the application (run only after the previous script run has completed):" -ForegroundColor Yellow
+        Write-Host "     python ./scripts/post_deploy.py --skip-tests" -ForegroundColor Cyan
 
-        # Ensure post-deploy Python dependencies are installed
-        $python = "python"
-        if (Test-Path "./.venv/Scripts/python.exe") { $python = "./.venv/Scripts/python.exe" }
-        elseif (Test-Path "../.venv/Scripts/python.exe") { $python = "../.venv/Scripts/python.exe" }
-        elseif (Test-Path "./.venv/bin/python") { $python = "./.venv/bin/python" }
-        elseif (Test-Path "../.venv/bin/python") { $python = "../.venv/bin/python" }
-        & $python -m pip install -r ./scripts/requirements-post-deploy.txt --quiet | Out-Null
-        
-        if (Test-Path "./scripts/post_deploy.py") {
-          & $python ./scripts/post_deploy.py --skip-tests
-          
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host "Post-deploy script completed successfully!" -ForegroundColor Green
-          } else {
-            Write-Host "Post-deploy script completed with warnings (some steps may have failed)" -ForegroundColor Yellow
-          }
-        } else {
-          Write-Host "Warning: post_deploy.py not found, skipping sample data upload" -ForegroundColor Yellow
-        }
-        
         Write-Host ""
-        Write-Host "===== Deployment Complete =====" -ForegroundColor Green
-        Write-Host ""
-        Write-Host "Access the web application:"
-        Write-Host "   $env:WEB_APP_URL" -ForegroundColor Cyan
+        Write-Host "Web app URL: " -NoNewline
+        Write-Host "$env:WEB_APP_URL" -ForegroundColor Cyan
       shell: pwsh
       continueOnError: false
       interactive: true
     posix:
       run: |
-        echo "===== Provision Complete ====="
-        echo ""
-        echo "Web App URL: $WEB_APP_URL"
-        echo "Storage Account: $AZURE_BLOB_ACCOUNT_NAME"
-        echo "AI Search Service: $AI_SEARCH_SERVICE_NAME"
-        echo "AI Search Index: $AZURE_AI_SEARCH_PRODUCTS_INDEX"
-        echo "AI Service Location: $AZURE_ENV_AI_SERVICE_LOCATION"
-        echo "Container Instance: $CONTAINER_INSTANCE_NAME"
-        
-        echo ""
-        echo "Container Registry: $AZURE_ENV_CONTAINER_REGISTRY_NAME"
-        
-        # Run post-deploy script to upload sample data and create search index
-        echo ""
-        # Note: Cosmos DB role is assigned to deployer via Bicep.
-        echo "===== Running Post-Deploy Script ====="
-        echo "This will upload sample data and create the search index..."
-        
-        if [ -f "./scripts/post_deploy.py" ]; then
-          # Prefer local venv if present (repo root or content-gen)
-          if [ -x "./.venv/bin/python" ]; then
-            PYTHON_BIN="./.venv/bin/python"
-          elif [ -x "../.venv/bin/python" ]; then
-            PYTHON_BIN="../.venv/bin/python"
-          else
-            PYTHON_BIN="python3"
-          fi
+        echo "===== Provisioning Complete ====="
+        echo "Run the following two scripts, in order:"
+        echo "  1. Build and push the application images to ACR, then update the web app and container instance:"
+        echo "     bash ./infra/scripts/build_and_deploy_images.sh"
+        echo "  2. Load the sample data into the application (run only after the previous script run has completed):"
+        echo "     python ./scripts/post_deploy.py --skip-tests"
 
-          "$PYTHON_BIN" -m pip install -r ./scripts/requirements-post-deploy.txt --quiet > /dev/null \
-            && "$PYTHON_BIN" ./scripts/post_deploy.py --skip-tests \
-            && echo "Post-deploy script completed successfully!" \
-            || echo "Post-deploy script completed with warnings (some steps may have failed)"
-        else
-          echo "Warning: post_deploy.py not found, skipping sample data upload"
-        fi
-        
         echo ""
-        echo "===== Deployment Complete ====="
-        echo ""
-        echo "Access the web application:"
-        echo "   $WEB_APP_URL"
+        echo "Web app URL: $WEB_APP_URL"
       shell: sh
       continueOnError: false
       interactive: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -60,7 +60,7 @@ hooks:
         Write-Host "  1. Build and push the application images to ACR, then update the web app and container instance:" -ForegroundColor Yellow
         Write-Host "     ./infra/scripts/build_and_deploy_images.ps1" -ForegroundColor Cyan
         Write-Host "  2. Load the sample data into the application (run only after the previous script run has completed):" -ForegroundColor Yellow
-        Write-Host "     python ./scripts/post_deploy.py --skip-tests" -ForegroundColor Cyan
+        Write-Host "     ./infra/scripts/process_sample_data.ps1" -ForegroundColor Cyan
 
         Write-Host ""
         Write-Host "Web app URL: " -NoNewline
@@ -74,8 +74,9 @@ hooks:
         echo "Run the following two scripts, in order:"
         echo "  1. Build and push the application images to ACR, then update the web app and container instance:"
         echo "     bash ./infra/scripts/build_and_deploy_images.sh"
+        echo " "
         echo "  2. Load the sample data into the application (run only after the previous script run has completed):"
-        echo "     python ./scripts/post_deploy.py --skip-tests"
+        echo "     bash ./infra/scripts/process_sample_data.sh"
 
         echo ""
         echo "Web app URL: $WEB_APP_URL"

--- a/docs/AZD_DEPLOYMENT.md
+++ b/docs/AZD_DEPLOYMENT.md
@@ -119,14 +119,67 @@ azd config set provision.preflight off
 azd up
 ```
 
-This single command will:
-1. **Provision** all Azure resources (AI Services, Cosmos DB, Storage, AI Search, App Service, Container Registry)
-2. **Build** the Docker container image and push to ACR
-3. **Deploy** the container to Azure Container Instances
-4. **Build** the frontend (React/TypeScript)
-5. **Deploy** the frontend to App Service
-6. **Configure** RBAC and Cosmos DB roles
-7. **Upload** sample data and create the search index
+This command will **provision** all Azure resources (AI Services, Cosmos DB, Storage, AI Search, App Service, Container Instance, Container Registry) and configure RBAC and Cosmos DB roles. The Container Registry (ACR) is initially deployed with placeholder images; the application images are built and pushed by the follow-up scripts below.
+
+When provisioning completes, the terminal prints the two follow-up scripts you must run, **in order**, to finish the deployment.
+
+### 5. Log in to Azure CLI
+
+These scripts use the Azure CLI, so log in first:
+
+```bash
+az login
+```
+
+Alternatively, log in using a device code (**recommended when using VS Code Web**):
+
+```bash
+az login --use-device-code
+```
+
+> **Note:** If you are running this deployment in **GitHub Codespaces**, a **VS Code Dev Container**, or **VS Code Web**, skip this step and continue with [step 7](#7-run-the-script-to-build-and-push-the-application-images).
+
+### 6. Create and activate a Python virtual environment
+
+```powershell
+# PowerShell (Windows)
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+```
+
+```bash
+# Bash (macOS/Linux, or Git Bash on Windows)
+python -m venv .venv
+source .venv/bin/activate        # on Git Bash (Windows): source .venv/Scripts/activate
+```
+
+### 7. Run the script to build and push the application images
+
+Build and push the frontend and backend images to ACR, then update the App Service and Container Instance:
+
+```powershell
+# PowerShell
+./infra/scripts/build_and_deploy_images.ps1
+```
+
+```bash
+# Bash
+bash ./infra/scripts/build_and_deploy_images.sh
+```
+
+### 8. Run the script to load the sample data (script 2)
+
+Run this **only after step 7 has completed** — it loads the sample data into the application:
+
+```powershell
+# PowerShell
+./infra/scripts/process_sample_data.ps1
+```
+
+```bash
+# Bash
+bash ./infra/scripts/process_sample_data.sh
+```
 
 ## Using Existing Resources
 
@@ -146,14 +199,20 @@ azd env set AZURE_ENV_EXISTING_LOG_ANALYTICS_WORKSPACE_RID "/subscriptions/<sub-
 
 ## Post-Deployment
 
-After `azd up` completes, you'll see output like:
+After `azd up` completes, the terminal prints the provisioning summary and the two follow-up scripts to run:
 
 ```
-===== Deployment Complete =====
+===== Provisioning Complete =====
+Run the following two scripts, in order:
+  1. Build and push the application images to ACR, then update the web app and container instance:
+     ./infra/scripts/build_and_deploy_images.ps1
+  2. Load the sample data into the application (run only after the previous script run has completed):
+     ./infra/scripts/process_sample_data.ps1
 
-Access the web application:
-   https://app-<env-name>.azurewebsites.net
+Web app URL: https://app-<env-name>.azurewebsites.net
 ```
+
+Run those two scripts as described in [steps 5–8](#5-log-in-to-azure-cli) above, then verify the deployment.
 
 ### Verify Deployment
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -166,6 +166,8 @@ Depending on your subscription quota and capacity, you can adjust quota settings
 
 Once you've opened the project in [Codespaces](#github-codespaces), [Dev Containers](#vs-code-dev-containers), or [locally](#local-environment), you can deploy it to Azure by following the steps in the [AZD Deployment Guide](AZD_DEPLOYMENT.md).
 
+> **Important:** `azd up` only **provisions** the Azure resources (the Container Registry is created with placeholder images). Once provisioning completes, you must run the **two follow-up scripts**, in order - first `build_and_deploy_images` (builds and pushes the application images to ACR and updates the App Service and Container Instance), then `process_sample_data` (loads the sample data). See [Post-Provision Scripts (steps 5–8)](AZD_DEPLOYMENT.md#5-log-in-to-azure-cli) for details.
+
 ## Post Deployment Steps
 
 1. **Add App Authentication**

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -104,6 +104,14 @@ param existingLogAnalyticsWorkspaceId string = ''
 @description('Optional. Resource ID of an existing Foundry project.')
 param azureExistingAIProjectResourceId string = ''
 
+@description('Optional. Principal type of the deployer, used for the ACR AcrPush role assignment. Set to ServicePrincipal for CI/OIDC deployments; defaults to User for interactive deployments.')
+@allowed([
+  'User'
+  'Group'
+  'ServicePrincipal'
+])
+param deployerType string = 'User'
+
 @description('Optional. Deploy Azure Bastion and Jumpbox resources for private network administration.')
 param deployBastionAndJumpbox bool = false
 
@@ -391,7 +399,7 @@ module containerRegistry 'modules/container-registry.bicep' = {
     pushPrincipalIds: [
       deployer().objectId
     ]
-    pushPrincipalType: 'User'
+    deployerType: deployerType
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -135,12 +135,6 @@ param enableRedundancy bool = false
 @description('Optional. Enable private networking for applicable resources (WAF-aligned).')
 param enablePrivateNetworking bool = false
 
-@description('Optional. The existing Container Registry name (without .azurecr.io). Must contain pre-built images: content-gen-app and content-gen-api.')
-param acrName string = 'contentgencontainerreg'
-
-@description('Optional. Image Tag.')
-param imageTag string = 'latest'
-
 @description('Optional. Enable/Disable usage telemetry for module.')
 param enableTelemetry bool = true
 
@@ -153,8 +147,6 @@ param createdBy string = contains(deployer(), 'userPrincipalName')? split(deploy
 
 var solutionLocation = empty(location) ? resourceGroup().location : location
 
-// acrName is required - points to existing ACR with pre-built images
-var acrResourceName = acrName
 var solutionSuffix = toLower(trim(replace(
   replace(
     replace(replace(replace(replace('${solutionName}${solutionUniqueText}', '-', ''), '_', ''), '.', ''), '/', ''),
@@ -369,6 +361,33 @@ module userAssignedIdentity 'br/public:avm/res/managed-identity/user-assigned-id
     location: solutionLocation
     tags: tags
     enableTelemetry: enableTelemetry
+  }
+}
+
+// ========== Azure Container Registry ========== //
+// Provisions the ACR and grants AcrPull to the shared managed identity (used by
+// both the frontend App Service and the backend Container Instance). Application
+// images are built and pushed to this ACR by a post-deployment step.
+module containerRegistry 'modules/container-registry.bicep' = {
+  name: take('module.container-registry.${solutionSuffix}', 64)
+  params: {
+    name: 'cr${solutionSuffix}'
+    location: solutionLocation
+    tags: tags
+    enableTelemetry: enableTelemetry
+    acrSku: 'Standard'
+    managedIdentities: {
+      userAssignedResourceIds: [
+        userAssignedIdentity.outputs.resourceId
+      ]
+    }
+    pullPrincipalIds: [
+      userAssignedIdentity.outputs.principalId
+    ]
+    pushPrincipalIds: [
+      deployer().objectId
+    ]
+    pushPrincipalType: 'User'
   }
 }
 
@@ -966,11 +985,13 @@ module webSite 'modules/web-sites.bicep' = {
     serverFarmResourceId: webServerFarm.outputs.resourceId
     managedIdentities: { userAssignedResourceIds: [userAssignedIdentity!.outputs.resourceId] }
     siteConfig: {
-      // Frontend container - same for both modes
-      linuxFxVersion: 'DOCKER|${acrResourceName}.azurecr.io/content-gen-app:${imageTag}'
+      // Frontend container - hello-world placeholder (updated post-deployment)
+      linuxFxVersion: 'DOCKER|mcr.microsoft.com/azuredocs/aci-helloworld:latest'
       minTlsVersion: '1.2'
       alwaysOn: true
       ftpsState: 'FtpsOnly'
+      acrUseManagedIdentityCreds: true
+      acrUserManagedIdentityID: userAssignedIdentity!.outputs.clientId
     }
     virtualNetworkSubnetId: enablePrivateNetworking ? virtualNetwork!.outputs.webSubnetResourceId : null
     configs: concat(
@@ -979,7 +1000,7 @@ module webSite 'modules/web-sites.bicep' = {
           // Frontend container proxies to ACI backend (both modes)
           name: 'appsettings'
           properties: {
-            DOCKER_REGISTRY_SERVER_URL: 'https://${acrResourceName}.azurecr.io'
+            DOCKER_REGISTRY_SERVER_URL: 'https://${containerRegistry.outputs.loginServer}'
             BACKEND_URL: aciBackendUrl
             AZURE_CLIENT_ID: userAssignedIdentity.outputs.clientId
           }
@@ -1013,13 +1034,14 @@ module containerInstance 'modules/container-instance.bicep' = {
     name: containerInstanceName
     location: solutionLocation
     tags: tags
-    containerImage: '${acrResourceName}.azurecr.io/content-gen-api:${imageTag}'
+    containerImage: 'mcr.microsoft.com/azuredocs/aci-helloworld:latest'
     cpu: 2
     memoryInGB: 4
     port: 8000
     // Only pass subnetResourceId when private networking is enabled
     subnetResourceId: enablePrivateNetworking ? virtualNetwork!.outputs.aciSubnetResourceId : ''
     userAssignedIdentityResourceId: userAssignedIdentity.outputs.resourceId
+    acrLoginServer: containerRegistry.outputs.loginServer
     enableTelemetry: enableTelemetry
     environmentVariables: [
       // Azure OpenAI Settings
@@ -1144,7 +1166,7 @@ output CONTAINER_INSTANCE_NAME string = containerInstance.outputs.name
 output CONTAINER_INSTANCE_FQDN string = enablePrivateNetworking ? '' : containerInstance.outputs.fqdn
 
 @description('Contains ACR Name')
-output AZURE_ENV_CONTAINER_REGISTRY_NAME string = acrResourceName
+output AZURE_ENV_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
 
 @description('Contains flag for Azure AI Foundry usage')
 output USE_FOUNDRY bool = useFoundryMode ? true : false

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -376,6 +376,10 @@ module containerRegistry 'modules/container-registry.bicep' = {
     tags: tags
     enableTelemetry: enableTelemetry
     acrSku: 'Standard'
+    enablePrivateNetworking: enablePrivateNetworking
+    enableScalability: enableScalability
+    privateEndpointSubnetResourceId: enablePrivateNetworking ? virtualNetwork!.outputs.pepsSubnetResourceId : ''
+    privateDnsZoneResourceId: enablePrivateNetworking ? avmPrivateDnsZones[dnsZoneIndex.containerRegistry]!.outputs.resourceId : ''
     managedIdentities: {
       userAssignedResourceIds: [
         userAssignedIdentity.outputs.resourceId
@@ -567,11 +571,13 @@ module jumpboxDcr 'br/public:avm/res/insights/data-collection-rule:0.11.0' = if 
 // - OpenAI (for Azure OpenAI endpoints)
 // - Blob Storage
 // - Cosmos DB (Documents)
+// - Container Registry (for private image pulls)
 var privateDnsZones = [
   'privatelink.cognitiveservices.azure.com'
   'privatelink.openai.azure.com'
   'privatelink.blob.${environment().suffixes.storage}'
   'privatelink.documents.azure.com'
+  'privatelink.azurecr.io'
 ]
 
 var dnsZoneIndex = {
@@ -579,6 +585,7 @@ var dnsZoneIndex = {
   openAI: 1
   storageBlob: 2
   cosmosDB: 3
+  containerRegistry: 4
 }
 
 @batchSize(5)

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "18281771994413307619"
+      "templateHash": "12340397001946101697"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -344,13 +344,15 @@
       "privatelink.cognitiveservices.azure.com",
       "privatelink.openai.azure.com",
       "[format('privatelink.blob.{0}', environment().suffixes.storage)]",
-      "privatelink.documents.azure.com"
+      "privatelink.documents.azure.com",
+      "privatelink.azurecr.io"
     ],
     "dnsZoneIndex": {
       "cognitiveServices": 0,
       "openAI": 1,
       "storageBlob": 2,
-      "cosmosDB": 3
+      "cosmosDB": 3,
+      "containerRegistry": 4
     },
     "storageAccountName": "[format('st{0}', variables('solutionSuffix'))]",
     "productImagesContainer": "product-images",
@@ -4817,6 +4819,14 @@
           "acrSku": {
             "value": "Standard"
           },
+          "enablePrivateNetworking": {
+            "value": "[parameters('enablePrivateNetworking')]"
+          },
+          "enableScalability": {
+            "value": "[parameters('enableScalability')]"
+          },
+          "privateEndpointSubnetResourceId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.pepsSubnetResourceId.value), createObject('value', ''))]",
+          "privateDnsZoneResourceId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference(format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').containerRegistry)).outputs.resourceId.value), createObject('value', ''))]",
           "managedIdentities": {
             "value": {
               "userAssignedResourceIds": [
@@ -4846,7 +4856,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "8532463912224257721"
+              "templateHash": "553009202159475069"
             }
           },
           "definitions": {
@@ -4945,6 +4955,34 @@
                 "description": "Optional. Principal type for the AcrPush role assignments."
               }
             },
+            "enablePrivateNetworking": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Enable private networking. Forces the Premium SKU, disables public network access and creates a private endpoint for the registry."
+              }
+            },
+            "enableScalability": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Optional. Enable scalability. Bumps the registry to the Premium SKU (WAF-aligned) to allow geo-replication and higher throughput."
+              }
+            },
+            "privateEndpointSubnetResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Resource ID of the subnet to host the registry private endpoint. Required when enablePrivateNetworking is true."
+              }
+            },
+            "privateDnsZoneResourceId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. Resource ID of the privatelink.azurecr.io private DNS zone. Required when enablePrivateNetworking is true."
+              }
+            },
             "managedIdentities": {
               "$ref": "#/definitions/managedIdentityAllType",
               "nullable": true,
@@ -4975,7 +5013,8 @@
               }
             ],
             "acrPullRoleDefinitionId": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
-            "acrPushRoleDefinitionId": "8311e382-0749-4cb8-b61a-304f252e45ec"
+            "acrPushRoleDefinitionId": "8311e382-0749-4cb8-b61a-304f252e45ec",
+            "effectiveAcrSku": "[if(or(parameters('enablePrivateNetworking'), parameters('enableScalability')), 'Premium', parameters('acrSku'))]"
           },
           "resources": {
             "containerRegistry": {
@@ -5001,7 +5040,7 @@
                     "value": "[parameters('enableTelemetry')]"
                   },
                   "acrSku": {
-                    "value": "[parameters('acrSku')]"
+                    "value": "[variables('effectiveAcrSku')]"
                   },
                   "acrAdminUserEnabled": {
                     "value": false
@@ -5009,18 +5048,28 @@
                   "anonymousPullEnabled": {
                     "value": false
                   },
-                  "publicNetworkAccess": {
-                    "value": "Enabled"
+                  "azureADAuthenticationAsArmPolicyStatus": {
+                    "value": "enabled"
                   },
-                  "networkRuleBypassOptions": {
-                    "value": "AzureServices"
+                  "exportPolicyStatus": {
+                    "value": "enabled"
                   },
+                  "softDeletePolicyStatus": {
+                    "value": "disabled"
+                  },
+                  "softDeletePolicyDays": {
+                    "value": 7
+                  },
+                  "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
+                  "networkRuleBypassOptions": "[if(or(parameters('enablePrivateNetworking'), parameters('enableScalability')), createObject('value', 'AzureServices'), createObject('value', null()))]",
+                  "networkRuleSetDefaultAction": "[if(or(parameters('enablePrivateNetworking'), parameters('enableScalability')), createObject('value', 'Deny'), createObject('value', 'Allow'))]",
                   "roleAssignments": {
                     "value": "[concat(variables('pullRoleAssignments'), variables('pushRoleAssignments'))]"
                   },
                   "managedIdentities": {
                     "value": "[parameters('managedIdentities')]"
-                  }
+                  },
+                  "privateEndpoints": "[if(parameters('enablePrivateNetworking'), createObject('value', createArray(createObject('name', format('pep-{0}', parameters('name')), 'customNetworkInterfaceName', format('nic-{0}', parameters('name')), 'service', 'registry', 'subnetResourceId', parameters('privateEndpointSubnetResourceId'), 'privateDnsZoneGroup', createObject('privateDnsZoneGroupConfigs', createArray(createObject('privateDnsZoneResourceId', parameters('privateDnsZoneResourceId'))))))), createObject('value', createArray()))]"
                 },
                 "template": {
                   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -8064,7 +8113,9 @@
         }
       },
       "dependsOn": [
-        "userAssignedIdentity"
+        "[format('avmPrivateDnsZones[{0}]', variables('dnsZoneIndex').containerRegistry)]",
+        "userAssignedIdentity",
+        "virtualNetwork"
       ]
     },
     "virtualNetwork": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "2883025917739612961"
+      "templateHash": "13991311501344883078"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -4868,7 +4868,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "6229495116704884486"
+              "templateHash": "15150176666831120984"
             }
           },
           "definitions": {
@@ -5073,8 +5073,8 @@
                     "value": 7
                   },
                   "publicNetworkAccess": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Disabled'), createObject('value', 'Enabled'))]",
-                  "networkRuleBypassOptions": "[if(or(parameters('enablePrivateNetworking'), parameters('enableScalability')), createObject('value', 'AzureServices'), createObject('value', null()))]",
-                  "networkRuleSetDefaultAction": "[if(or(parameters('enablePrivateNetworking'), parameters('enableScalability')), createObject('value', 'Deny'), createObject('value', 'Allow'))]",
+                  "networkRuleBypassOptions": "[if(parameters('enablePrivateNetworking'), createObject('value', 'AzureServices'), createObject('value', null()))]",
+                  "networkRuleSetDefaultAction": "[if(parameters('enablePrivateNetworking'), createObject('value', 'Deny'), createObject('value', 'Allow'))]",
                   "roleAssignments": {
                     "value": "[concat(variables('pullRoleAssignments'), variables('pushRoleAssignments'))]"
                   },

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "12340397001946101697"
+      "templateHash": "2883025917739612961"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -160,6 +160,18 @@
       "defaultValue": "",
       "metadata": {
         "description": "Optional. Resource ID of an existing Foundry project."
+      }
+    },
+    "deployerType": {
+      "type": "string",
+      "defaultValue": "User",
+      "allowedValues": [
+        "User",
+        "Group",
+        "ServicePrincipal"
+      ],
+      "metadata": {
+        "description": "Optional. Principal type of the deployer, used for the ACR AcrPush role assignment. Set to ServicePrincipal for CI/OIDC deployments; defaults to User for interactive deployments."
       }
     },
     "deployBastionAndJumpbox": {
@@ -4844,8 +4856,8 @@
               "[deployer().objectId]"
             ]
           },
-          "pushPrincipalType": {
-            "value": "User"
+          "deployerType": {
+            "value": "[parameters('deployerType')]"
           }
         },
         "template": {
@@ -4856,7 +4868,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "553009202159475069"
+              "templateHash": "6229495116704884486"
             }
           },
           "definitions": {
@@ -4943,7 +4955,7 @@
                 "description": "Optional. Principal IDs (e.g. the deployer) that require AcrPush access to build and push images."
               }
             },
-            "pushPrincipalType": {
+            "deployerType": {
               "type": "string",
               "defaultValue": "User",
               "allowedValues": [
@@ -5008,7 +5020,7 @@
                 "input": {
                   "principalId": "[parameters('pushPrincipalIds')[copyIndex('pushRoleAssignments')]]",
                   "roleDefinitionIdOrName": "[variables('acrPushRoleDefinitionId')]",
-                  "principalType": "[parameters('pushPrincipalType')]"
+                  "principalType": "[parameters('deployerType')]"
                 }
               }
             ],

--- a/infra/main.json
+++ b/infra/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "6689866125639874285"
+      "templateHash": "18281771994413307619"
     },
     "name": "Intelligent Content Generation Accelerator",
     "description": "Solution Accelerator for multimodal marketing content generation using Microsoft Agent Framework.\n"
@@ -232,20 +232,6 @@
         "description": "Optional. Enable private networking for applicable resources (WAF-aligned)."
       }
     },
-    "acrName": {
-      "type": "string",
-      "defaultValue": "contentgencontainerreg",
-      "metadata": {
-        "description": "Optional. The existing Container Registry name (without .azurecr.io). Must contain pre-built images: content-gen-app and content-gen-api."
-      }
-    },
-    "imageTag": {
-      "type": "string",
-      "defaultValue": "latest",
-      "metadata": {
-        "description": "Optional. Image Tag."
-      }
-    },
     "enableTelemetry": {
       "type": "bool",
       "defaultValue": true,
@@ -263,7 +249,6 @@
   },
   "variables": {
     "solutionLocation": "[if(empty(parameters('location')), resourceGroup().location, parameters('location'))]",
-    "acrResourceName": "[parameters('acrName')]",
     "solutionSuffix": "[toLower(trim(replace(replace(replace(replace(replace(replace(format('{0}{1}', parameters('solutionName'), parameters('solutionUniqueText')), '-', ''), '_', ''), '.', ''), '/', ''), ' ', ''), '*', '')))]",
     "cosmosDbZoneRedundantHaRegionPairs": {
       "australiaeast": "uksouth",
@@ -4806,6 +4791,3281 @@
           }
         }
       }
+    },
+    "containerRegistry": {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[take(format('module.container-registry.{0}', variables('solutionSuffix')), 64)]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "name": {
+            "value": "[format('cr{0}', variables('solutionSuffix'))]"
+          },
+          "location": {
+            "value": "[variables('solutionLocation')]"
+          },
+          "tags": {
+            "value": "[parameters('tags')]"
+          },
+          "enableTelemetry": {
+            "value": "[parameters('enableTelemetry')]"
+          },
+          "acrSku": {
+            "value": "Standard"
+          },
+          "managedIdentities": {
+            "value": {
+              "userAssignedResourceIds": [
+                "[reference('userAssignedIdentity').outputs.resourceId.value]"
+              ]
+            }
+          },
+          "pullPrincipalIds": {
+            "value": [
+              "[reference('userAssignedIdentity').outputs.principalId.value]"
+            ]
+          },
+          "pushPrincipalIds": {
+            "value": [
+              "[deployer().objectId]"
+            ]
+          },
+          "pushPrincipalType": {
+            "value": "User"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "languageVersion": "2.0",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.44.1.10279",
+              "templateHash": "8532463912224257721"
+            }
+          },
+          "definitions": {
+            "managedIdentityAllType": {
+              "type": "object",
+              "properties": {
+                "systemAssigned": {
+                  "type": "bool",
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. Enables system assigned managed identity on the resource."
+                  }
+                },
+                "userAssignedResourceIds": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "nullable": true,
+                  "metadata": {
+                    "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                  }
+                }
+              },
+              "metadata": {
+                "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                "__bicep_imported_from!": {
+                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.7.0"
+                }
+              }
+            }
+          },
+          "parameters": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "Required. Name of the Azure Container Registry."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Optional. Location for the Container Registry."
+              }
+            },
+            "tags": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Optional. Tags for all resources."
+              }
+            },
+            "enableTelemetry": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Optional. Enable/Disable usage telemetry for module."
+              }
+            },
+            "acrSku": {
+              "type": "string",
+              "defaultValue": "Standard",
+              "allowedValues": [
+                "Basic",
+                "Standard",
+                "Premium"
+              ],
+              "metadata": {
+                "description": "Optional. SKU for the Container Registry."
+              }
+            },
+            "pullPrincipalIds": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional. Principal IDs (frontend/backend managed identities) that require AcrPull access."
+              }
+            },
+            "pushPrincipalIds": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Optional. Principal IDs (e.g. the deployer) that require AcrPush access to build and push images."
+              }
+            },
+            "pushPrincipalType": {
+              "type": "string",
+              "defaultValue": "User",
+              "allowedValues": [
+                "User",
+                "Group",
+                "ServicePrincipal"
+              ],
+              "metadata": {
+                "description": "Optional. Principal type for the AcrPush role assignments."
+              }
+            },
+            "managedIdentities": {
+              "$ref": "#/definitions/managedIdentityAllType",
+              "nullable": true,
+              "metadata": {
+                "description": "Optional. The managed identity definition for this resource."
+              }
+            }
+          },
+          "variables": {
+            "copy": [
+              {
+                "name": "pullRoleAssignments",
+                "count": "[length(parameters('pullPrincipalIds'))]",
+                "input": {
+                  "principalId": "[parameters('pullPrincipalIds')[copyIndex('pullRoleAssignments')]]",
+                  "roleDefinitionIdOrName": "[variables('acrPullRoleDefinitionId')]",
+                  "principalType": "ServicePrincipal"
+                }
+              },
+              {
+                "name": "pushRoleAssignments",
+                "count": "[length(parameters('pushPrincipalIds'))]",
+                "input": {
+                  "principalId": "[parameters('pushPrincipalIds')[copyIndex('pushRoleAssignments')]]",
+                  "roleDefinitionIdOrName": "[variables('acrPushRoleDefinitionId')]",
+                  "principalType": "[parameters('pushPrincipalType')]"
+                }
+              }
+            ],
+            "acrPullRoleDefinitionId": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+            "acrPushRoleDefinitionId": "8311e382-0749-4cb8-b61a-304f252e45ec"
+          },
+          "resources": {
+            "containerRegistry": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "[take(format('avm.res.container-registry.registry.{0}', parameters('name')), 64)]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "name": {
+                    "value": "[parameters('name')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  },
+                  "tags": {
+                    "value": "[parameters('tags')]"
+                  },
+                  "enableTelemetry": {
+                    "value": "[parameters('enableTelemetry')]"
+                  },
+                  "acrSku": {
+                    "value": "[parameters('acrSku')]"
+                  },
+                  "acrAdminUserEnabled": {
+                    "value": false
+                  },
+                  "anonymousPullEnabled": {
+                    "value": false
+                  },
+                  "publicNetworkAccess": {
+                    "value": "Enabled"
+                  },
+                  "networkRuleBypassOptions": {
+                    "value": "AzureServices"
+                  },
+                  "roleAssignments": {
+                    "value": "[concat(variables('pullRoleAssignments'), variables('pushRoleAssignments'))]"
+                  },
+                  "managedIdentities": {
+                    "value": "[parameters('managedIdentities')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "languageVersion": "2.0",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.33.93.31351",
+                      "templateHash": "4815545096063729768"
+                    },
+                    "name": "Azure Container Registries (ACR)",
+                    "description": "This module deploys an Azure Container Registry (ACR)."
+                  },
+                  "definitions": {
+                    "privateEndpointOutputType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "The name of the private endpoint."
+                          }
+                        },
+                        "resourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "The resource ID of the private endpoint."
+                          }
+                        },
+                        "groupId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "The group Id for the private endpoint Group."
+                          }
+                        },
+                        "customDnsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fqdn": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "FQDN that resolves to private endpoint IP address."
+                                }
+                              },
+                              "ipAddresses": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "metadata": {
+                                  "description": "A list of private IP addresses of the private endpoint."
+                                }
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "The custom DNS configurations of the private endpoint."
+                          }
+                        },
+                        "networkInterfaceResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "description": "The IDs of the network interfaces associated with the private endpoint."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true
+                      }
+                    },
+                    "scopeMapsType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the scope map."
+                          }
+                        },
+                        "actions": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "description": "Required. The list of scoped permissions for registry artifacts."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The user friendly description of the scope map."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a scope map."
+                      }
+                    },
+                    "cacheRuleType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                          }
+                        },
+                        "sourceRepository": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. Source repository pulled from upstream."
+                          }
+                        },
+                        "targetRepository": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                          }
+                        },
+                        "credentialSetResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID of the credential store which is associated with the cache rule."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a cache rule."
+                      }
+                    },
+                    "credentialSetType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the credential set."
+                          }
+                        },
+                        "managedIdentities": {
+                          "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The managed identity definition for this resource."
+                          }
+                        },
+                        "authCredentials": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/authCredentialsType"
+                          },
+                          "metadata": {
+                            "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                          }
+                        },
+                        "loginServer": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The credentials are stored for this upstream or login server."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a credential set."
+                      }
+                    },
+                    "replicationType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the replication."
+                          }
+                        },
+                        "location": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Location for all resources."
+                          }
+                        },
+                        "tags": {
+                          "type": "object",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Tags of the resource."
+                          }
+                        },
+                        "regionEndpointEnabled": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
+                          }
+                        },
+                        "zoneRedundancy": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Disabled",
+                            "Enabled"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a replication."
+                      }
+                    },
+                    "webhookType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "minLength": 5,
+                          "maxLength": 50,
+                          "metadata": {
+                            "description": "Optional. The name of the registry webhook."
+                          }
+                        },
+                        "serviceUri": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The service URI for the webhook to post notifications."
+                          }
+                        },
+                        "status": {
+                          "type": "string",
+                          "allowedValues": [
+                            "disabled",
+                            "enabled"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The status of the webhook at the time the operation was called."
+                          }
+                        },
+                        "action": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                          }
+                        },
+                        "location": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Location for all resources."
+                          }
+                        },
+                        "tags": {
+                          "type": "object",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Tags of the resource."
+                          }
+                        },
+                        "customHeaders": {
+                          "type": "object",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Custom headers that will be added to the webhook notifications."
+                          }
+                        },
+                        "scope": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_export!": true,
+                        "description": "The type for a webhook."
+                      }
+                    },
+                    "_1.privateEndpointCustomDnsConfigType": {
+                      "type": "object",
+                      "properties": {
+                        "fqdn": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. FQDN that resolves to private endpoint IP address."
+                          }
+                        },
+                        "ipAddresses": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "description": "Required. A list of private IP addresses of the private endpoint."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "_1.privateEndpointIpConfigurationType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the resource that is unique within a resource group."
+                          }
+                        },
+                        "properties": {
+                          "type": "object",
+                          "properties": {
+                            "groupId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to."
+                              }
+                            },
+                            "memberName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to."
+                              }
+                            },
+                            "privateIPAddress": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "Required. Properties of private endpoint IP configurations."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "_1.privateEndpointPrivateDnsZoneGroupType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the Private DNS Zone Group."
+                          }
+                        },
+                        "privateDnsZoneGroupConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. The name of the private DNS Zone Group config."
+                                }
+                              },
+                              "privateDnsZoneResourceId": {
+                                "type": "string",
+                                "metadata": {
+                                  "description": "Required. The resource id of the private DNS zone."
+                                }
+                              }
+                            }
+                          },
+                          "metadata": {
+                            "description": "Required. The private DNS Zone Groups to associate the Private Endpoint. A DNS Zone Group can support up to 5 DNS zones."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "authCredentialsType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the credential."
+                          }
+                        },
+                        "usernameSecretIdentifier": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. KeyVault Secret URI for accessing the username."
+                          }
+                        },
+                        "passwordSecretIdentifier": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. KeyVault Secret URI for accessing the password."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "The type for auth credentials.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "credential-set/main.bicep"
+                        }
+                      }
+                    },
+                    "customerManagedKeyWithAutoRotateType": {
+                      "type": "object",
+                      "properties": {
+                        "keyVaultResourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+                          }
+                        },
+                        "keyName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The name of the customer managed key to use for encryption."
+                          }
+                        },
+                        "keyVersion": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using version as per 'autoRotationEnabled' setting."
+                          }
+                        },
+                        "autoRotationEnabled": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enable or disable auto-rotating to the latest key version. Default is `true`. If set to `false`, the latest key version at the time of the deployment is used."
+                          }
+                        },
+                        "userAssignedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a customer-managed key. To be used if the resource type supports auto-rotation of the customer-managed key.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "diagnosticSettingFullType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the diagnostic setting."
+                          }
+                        },
+                        "logCategoriesAndGroups": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Name of a Diagnostic Log category for a resource type this setting is applied to. Set the specific logs to collect here."
+                                }
+                              },
+                              "categoryGroup": {
+                                "type": "string",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Name of a Diagnostic Log category group for a resource type this setting is applied to. Set to `allLogs` to collect all logs."
+                                }
+                              },
+                              "enabled": {
+                                "type": "bool",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                }
+                              }
+                            }
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of logs that will be streamed. \"allLogs\" includes all possible logs for the resource. Set to `[]` to disable log collection."
+                          }
+                        },
+                        "metricCategories": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "category": {
+                                "type": "string",
+                                "metadata": {
+                                  "description": "Required. Name of a Diagnostic Metric category for a resource type this setting is applied to. Set to `AllMetrics` to collect all metrics."
+                                }
+                              },
+                              "enabled": {
+                                "type": "bool",
+                                "nullable": true,
+                                "metadata": {
+                                  "description": "Optional. Enable or disable the category explicitly. Default is `true`."
+                                }
+                              }
+                            }
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of metrics that will be streamed. \"allMetrics\" includes all possible metrics for the resource. Set to `[]` to disable metric collection."
+                          }
+                        },
+                        "logAnalyticsDestinationType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "AzureDiagnostics",
+                            "Dedicated"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. A string indicating whether the export to Log Analytics should use the default destination type, i.e. AzureDiagnostics, or use a destination type."
+                          }
+                        },
+                        "workspaceResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic log analytics workspace. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "storageAccountResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic storage account. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "eventHubAuthorizationRuleResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Resource ID of the diagnostic event hub authorization rule for the Event Hubs namespace in which the event hub should be created or streamed to."
+                          }
+                        },
+                        "eventHubName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Name of the diagnostic event hub within the namespace to which logs are streamed. Without this, an event hub is created for each log category. For security reasons, it is recommended to set diagnostic settings to send data to either storage account, log analytics workspace or event hub."
+                          }
+                        },
+                        "marketplacePartnerResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The full ARM resource ID of the Marketplace resource to which you would like to send Diagnostic Logs."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a diagnostic setting. To be used if both logs & metrics are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "lockType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the name of lock."
+                          }
+                        },
+                        "kind": {
+                          "type": "string",
+                          "allowedValues": [
+                            "CanNotDelete",
+                            "None",
+                            "ReadOnly"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a lock.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "managedIdentityAllType": {
+                      "type": "object",
+                      "properties": {
+                        "systemAssigned": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enables system assigned managed identity on the resource."
+                          }
+                        },
+                        "userAssignedResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID(s) to assign to the resource. Required if a user assigned identity is used for encryption."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a managed identity configuration. To be used if both a system-assigned & user-assigned identities are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "managedIdentityOnlySysAssignedType": {
+                      "type": "object",
+                      "properties": {
+                        "systemAssigned": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enables system assigned managed identity on the resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "privateEndpointSingleServiceType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the Private Endpoint."
+                          }
+                        },
+                        "location": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The location to deploy the Private Endpoint to."
+                          }
+                        },
+                        "privateLinkServiceConnectionName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name of the private link connection to create."
+                          }
+                        },
+                        "service": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The subresource to deploy the Private Endpoint for. For example \"vault\" for a Key Vault Private Endpoint."
+                          }
+                        },
+                        "subnetResourceId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                          }
+                        },
+                        "resourceGroupResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The resource ID of the Resource Group the Private Endpoint will be created in. If not specified, the Resource Group of the provided Virtual Network Subnet is used."
+                          }
+                        },
+                        "privateDnsZoneGroup": {
+                          "$ref": "#/definitions/_1.privateEndpointPrivateDnsZoneGroupType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The private DNS Zone Group to configure for the Private Endpoint."
+                          }
+                        },
+                        "isManualConnection": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. If Manual Private Link Connection is required."
+                          }
+                        },
+                        "manualConnectionRequestMessage": {
+                          "type": "string",
+                          "nullable": true,
+                          "maxLength": 140,
+                          "metadata": {
+                            "description": "Optional. A message passed to the owner of the remote resource with the manual connection request."
+                          }
+                        },
+                        "customDnsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/_1.privateEndpointCustomDnsConfigType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Custom DNS configurations."
+                          }
+                        },
+                        "ipConfigurations": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/_1.privateEndpointIpConfigurationType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. A list of IP configurations of the Private Endpoint. This will be used to map to the first-party Service endpoints."
+                          }
+                        },
+                        "applicationSecurityGroupResourceIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Application security groups in which the Private Endpoint IP configuration is included."
+                          }
+                        },
+                        "customNetworkInterfaceName": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The custom name of the network interface attached to the Private Endpoint."
+                          }
+                        },
+                        "lock": {
+                          "$ref": "#/definitions/lockType",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Specify the type of lock."
+                          }
+                        },
+                        "roleAssignments": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/roleAssignmentType"
+                          },
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Array of role assignments to create."
+                          }
+                        },
+                        "tags": {
+                          "type": "object",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Tags to be applied on all resources/Resource Groups in this deployment."
+                          }
+                        },
+                        "enableTelemetry": {
+                          "type": "bool",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Enable/Disable usage telemetry for module."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a private endpoint. To be used if the private endpoint's default service / groupId can be assumed (i.e., for services that only have one Private Endpoint type like 'vault' for key vault).",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    },
+                    "roleAssignmentType": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                          }
+                        },
+                        "roleDefinitionIdOrName": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                          }
+                        },
+                        "principalId": {
+                          "type": "string",
+                          "metadata": {
+                            "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                          }
+                        },
+                        "principalType": {
+                          "type": "string",
+                          "allowedValues": [
+                            "Device",
+                            "ForeignGroup",
+                            "Group",
+                            "ServicePrincipal",
+                            "User"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The principal type of the assigned principal ID."
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The description of the role assignment."
+                          }
+                        },
+                        "condition": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                          }
+                        },
+                        "conditionVersion": {
+                          "type": "string",
+                          "allowedValues": [
+                            "2.0"
+                          ],
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. Version of the condition."
+                          }
+                        },
+                        "delegatedManagedIdentityResourceId": {
+                          "type": "string",
+                          "nullable": true,
+                          "metadata": {
+                            "description": "Optional. The Resource Id of the delegated managed identity resource."
+                          }
+                        }
+                      },
+                      "metadata": {
+                        "description": "An AVM-aligned type for a role assignment.",
+                        "__bicep_imported_from!": {
+                          "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                        }
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "name": {
+                      "type": "string",
+                      "minLength": 5,
+                      "maxLength": 50,
+                      "metadata": {
+                        "description": "Required. Name of your Azure Container Registry."
+                      }
+                    },
+                    "acrAdminUserEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Enable admin user that have push / pull permission to the registry."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]",
+                      "metadata": {
+                        "description": "Optional. Location for all resources."
+                      }
+                    },
+                    "roleAssignments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/roleAssignmentType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of role assignments to create."
+                      }
+                    },
+                    "acrSku": {
+                      "type": "string",
+                      "defaultValue": "Premium",
+                      "allowedValues": [
+                        "Basic",
+                        "Premium",
+                        "Standard"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Tier of your Azure container registry."
+                      }
+                    },
+                    "exportPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the export policy is enabled or not."
+                      }
+                    },
+                    "quarantinePolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the quarantine policy is enabled or not. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "trustPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the trust policy is enabled or not. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "retentionPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "enabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the retention policy is enabled or not."
+                      }
+                    },
+                    "retentionPolicyDays": {
+                      "type": "int",
+                      "defaultValue": 15,
+                      "metadata": {
+                        "description": "Optional. The number of days to retain an untagged manifest after which it gets purged."
+                      }
+                    },
+                    "azureADAuthenticationAsArmPolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "enabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The value that indicates whether the policy for using ARM audience token for a container registry is enabled or not. Default is enabled."
+                      }
+                    },
+                    "softDeletePolicyStatus": {
+                      "type": "string",
+                      "defaultValue": "disabled",
+                      "allowedValues": [
+                        "disabled",
+                        "enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Soft Delete policy status. Default is disabled."
+                      }
+                    },
+                    "softDeletePolicyDays": {
+                      "type": "int",
+                      "defaultValue": 7,
+                      "metadata": {
+                        "description": "Optional. The number of days after which a soft-deleted item is permanently deleted."
+                      }
+                    },
+                    "dataEndpointEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Enable a single data endpoint per region for serving data. Not relevant in case of disabled public access. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "publicNetworkAccess": {
+                      "type": "string",
+                      "nullable": true,
+                      "allowedValues": [
+                        "Enabled",
+                        "Disabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkRuleSetIpRules are not set.  Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "networkRuleBypassOptions": {
+                      "type": "string",
+                      "defaultValue": "AzureServices",
+                      "allowedValues": [
+                        "AzureServices",
+                        "None"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Whether to allow trusted Azure services to access a network restricted registry."
+                      }
+                    },
+                    "networkRuleSetDefaultAction": {
+                      "type": "string",
+                      "defaultValue": "Deny",
+                      "allowedValues": [
+                        "Allow",
+                        "Deny"
+                      ],
+                      "metadata": {
+                        "description": "Optional. The default action of allow or deny when no other rules match."
+                      }
+                    },
+                    "networkRuleSetIpRules": {
+                      "type": "array",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The IP ACL rules. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "privateEndpoints": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateEndpointSingleServiceType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Configuration details for private endpoints. For security reasons, it is recommended to use private endpoints whenever possible. Note, requires the 'acrSku' to be 'Premium'."
+                      }
+                    },
+                    "zoneRedundancy": {
+                      "type": "string",
+                      "defaultValue": "Enabled",
+                      "allowedValues": [
+                        "Disabled",
+                        "Enabled"
+                      ],
+                      "metadata": {
+                        "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                      }
+                    },
+                    "replications": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/replicationType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. All replications to create."
+                      }
+                    },
+                    "webhooks": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/webhookType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. All webhooks to create."
+                      }
+                    },
+                    "lock": {
+                      "$ref": "#/definitions/lockType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The lock settings of the service."
+                      }
+                    },
+                    "managedIdentities": {
+                      "$ref": "#/definitions/managedIdentityAllType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The managed identity definition for this resource."
+                      }
+                    },
+                    "tags": {
+                      "type": "object",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Tags of the resource."
+                      }
+                    },
+                    "enableTelemetry": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Optional. Enable/Disable usage telemetry for module."
+                      }
+                    },
+                    "diagnosticSettings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/diagnosticSettingFullType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The diagnostic settings of the service."
+                      }
+                    },
+                    "anonymousPullEnabled": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Optional. Enables registry-wide pull from unauthenticated clients. It's in preview and available in the Standard and Premium service tiers."
+                      }
+                    },
+                    "customerManagedKey": {
+                      "$ref": "#/definitions/customerManagedKeyWithAutoRotateType",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. The customer managed key definition."
+                      }
+                    },
+                    "cacheRules": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/cacheRuleType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of Cache Rules."
+                      }
+                    },
+                    "credentialSets": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/credentialSetType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Array of Credential Sets."
+                      }
+                    },
+                    "scopeMaps": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/scopeMapsType"
+                      },
+                      "nullable": true,
+                      "metadata": {
+                        "description": "Optional. Scope maps setting."
+                      }
+                    }
+                  },
+                  "variables": {
+                    "copy": [
+                      {
+                        "name": "formattedRoleAssignments",
+                        "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                        "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                      }
+                    ],
+                    "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
+                    "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'SystemAssigned, UserAssigned', 'SystemAssigned'), if(not(empty(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createObject()))), 'UserAssigned', 'None')), 'userAssignedIdentities', if(not(empty(variables('formattedUserAssignedIdentities'))), variables('formattedUserAssignedIdentities'), null())), null())]",
+                    "builtInRoleNames": {
+                      "AcrDelete": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c2f4ef07-c644-48eb-af81-4b1b4947fb11')]",
+                      "AcrImageSigner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '6cef56e8-d556-48e5-a04f-b8e64114680f')]",
+                      "AcrPull": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')]",
+                      "AcrPush": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8311e382-0749-4cb8-b61a-304f252e45ec')]",
+                      "AcrQuarantineReader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'cdda3590-29a3-44f6-95f2-9f980659eb04')]",
+                      "AcrQuarantineWriter": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c8d4ff99-41c3-41a8-9f60-21dfdad59608')]",
+                      "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                      "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                      "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                      "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]",
+                      "User Access Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '18d7d88d-d35e-4fb5-a5c3-7773c20a72d9')]"
+                    }
+                  },
+                  "resources": {
+                    "cMKKeyVault::cMKKey": {
+                      "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
+                      "existing": true,
+                      "type": "Microsoft.KeyVault/vaults/keys",
+                      "apiVersion": "2023-02-01",
+                      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+                      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+                      "name": "[format('{0}/{1}', last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')), tryGet(parameters('customerManagedKey'), 'keyName'))]"
+                    },
+                    "avmTelemetry": {
+                      "condition": "[parameters('enableTelemetry')]",
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2024-03-01",
+                      "name": "[format('46d3xbcp.res.containerregistry-registry.{0}.{1}', replace('0.9.0', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                      "properties": {
+                        "mode": "Incremental",
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "contentVersion": "1.0.0.0",
+                          "resources": [],
+                          "outputs": {
+                            "telemetry": {
+                              "type": "String",
+                              "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "cMKKeyVault": {
+                      "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
+                      "existing": true,
+                      "type": "Microsoft.KeyVault/vaults",
+                      "apiVersion": "2023-02-01",
+                      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[2]]",
+                      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/')[4]]",
+                      "name": "[last(split(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '/'))]"
+                    },
+                    "cMKUserAssignedIdentity": {
+                      "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId')))]",
+                      "existing": true,
+                      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+                      "apiVersion": "2023-01-31",
+                      "subscriptionId": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[2]]",
+                      "resourceGroup": "[split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/')[4]]",
+                      "name": "[last(split(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '/'))]"
+                    },
+                    "registry": {
+                      "type": "Microsoft.ContainerRegistry/registries",
+                      "apiVersion": "2023-06-01-preview",
+                      "name": "[parameters('name')]",
+                      "location": "[parameters('location')]",
+                      "identity": "[variables('identity')]",
+                      "tags": "[parameters('tags')]",
+                      "sku": {
+                        "name": "[parameters('acrSku')]"
+                      },
+                      "properties": {
+                        "anonymousPullEnabled": "[parameters('anonymousPullEnabled')]",
+                        "adminUserEnabled": "[parameters('acrAdminUserEnabled')]",
+                        "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('status', 'enabled', 'keyVaultProperties', createObject('identity', if(not(empty(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), ''))), reference('cMKUserAssignedIdentity').clientId, null()), 'keyIdentifier', if(not(empty(tryGet(parameters('customerManagedKey'), 'keyVersion'))), format('{0}/{1}', reference('cMKKeyVault::cMKKey').keyUri, tryGet(parameters('customerManagedKey'), 'keyVersion')), if(coalesce(tryGet(parameters('customerManagedKey'), 'autoRotationEnabled'), true()), reference('cMKKeyVault::cMKKey').keyUri, reference('cMKKeyVault::cMKKey').keyUriWithVersion)))), null())]",
+                        "policies": {
+                          "azureADAuthenticationAsArmPolicy": {
+                            "status": "[parameters('azureADAuthenticationAsArmPolicyStatus')]"
+                          },
+                          "exportPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('status', parameters('exportPolicyStatus')), null())]",
+                          "quarantinePolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('status', parameters('quarantinePolicyStatus')), null())]",
+                          "trustPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('type', 'Notary', 'status', parameters('trustPolicyStatus')), null())]",
+                          "retentionPolicy": "[if(equals(parameters('acrSku'), 'Premium'), createObject('days', parameters('retentionPolicyDays'), 'status', parameters('retentionPolicyStatus')), null())]",
+                          "softDeletePolicy": {
+                            "retentionDays": "[parameters('softDeletePolicyDays')]",
+                            "status": "[parameters('softDeletePolicyStatus')]"
+                          }
+                        },
+                        "dataEndpointEnabled": "[parameters('dataEndpointEnabled')]",
+                        "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(not(empty(parameters('privateEndpoints'))), empty(parameters('networkRuleSetIpRules'))), 'Disabled', null()))]",
+                        "networkRuleBypassOptions": "[parameters('networkRuleBypassOptions')]",
+                        "networkRuleSet": "[if(not(empty(parameters('networkRuleSetIpRules'))), createObject('defaultAction', parameters('networkRuleSetDefaultAction'), 'ipRules', parameters('networkRuleSetIpRules')), null())]",
+                        "zoneRedundancy": "[if(equals(parameters('acrSku'), 'Premium'), parameters('zoneRedundancy'), null())]"
+                      },
+                      "dependsOn": [
+                        "cMKKeyVault::cMKKey",
+                        "cMKUserAssignedIdentity"
+                      ]
+                    },
+                    "registry_lock": {
+                      "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                      "type": "Microsoft.Authorization/locks",
+                      "apiVersion": "2020-05-01",
+                      "scope": "[format('Microsoft.ContainerRegistry/registries/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                      "properties": {
+                        "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                        "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_diagnosticSettings": {
+                      "copy": {
+                        "name": "registry_diagnosticSettings",
+                        "count": "[length(coalesce(parameters('diagnosticSettings'), createArray()))]"
+                      },
+                      "type": "Microsoft.Insights/diagnosticSettings",
+                      "apiVersion": "2021-05-01-preview",
+                      "scope": "[format('Microsoft.ContainerRegistry/registries/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'name'), format('{0}-diagnosticSettings', parameters('name')))]",
+                      "properties": {
+                        "copy": [
+                          {
+                            "name": "metrics",
+                            "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics'))))]",
+                            "input": {
+                              "category": "[coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')].category]",
+                              "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'metricCategories'), createArray(createObject('category', 'AllMetrics')))[copyIndex('metrics')], 'enabled'), true())]",
+                              "timeGrain": null
+                            }
+                          },
+                          {
+                            "name": "logs",
+                            "count": "[length(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs'))))]",
+                            "input": {
+                              "categoryGroup": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'categoryGroup')]",
+                              "category": "[tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'category')]",
+                              "enabled": "[coalesce(tryGet(coalesce(tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logCategoriesAndGroups'), createArray(createObject('categoryGroup', 'allLogs')))[copyIndex('logs')], 'enabled'), true())]"
+                            }
+                          }
+                        ],
+                        "storageAccountId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'storageAccountResourceId')]",
+                        "workspaceId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'workspaceResourceId')]",
+                        "eventHubAuthorizationRuleId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubAuthorizationRuleResourceId')]",
+                        "eventHubName": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'eventHubName')]",
+                        "marketplacePartnerId": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'marketplacePartnerResourceId')]",
+                        "logAnalyticsDestinationType": "[tryGet(coalesce(parameters('diagnosticSettings'), createArray())[copyIndex()], 'logAnalyticsDestinationType')]"
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_roleAssignments": {
+                      "copy": {
+                        "name": "registry_roleAssignments",
+                        "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                      },
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[format('Microsoft.ContainerRegistry/registries/{0}', parameters('name'))]",
+                      "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                      "properties": {
+                        "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                        "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                        "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                        "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                        "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                        "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                        "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_scopeMaps": {
+                      "copy": {
+                        "name": "registry_scopeMaps",
+                        "count": "[length(coalesce(parameters('scopeMaps'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Registry-Scope-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[tryGet(coalesce(parameters('scopeMaps'), createArray())[copyIndex()], 'name')]"
+                          },
+                          "actions": {
+                            "value": "[coalesce(parameters('scopeMaps'), createArray())[copyIndex()].actions]"
+                          },
+                          "description": {
+                            "value": "[tryGet(coalesce(parameters('scopeMaps'), createArray())[copyIndex()], 'description')]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "11112300500664950599"
+                            },
+                            "name": "Container Registries scopeMaps",
+                            "description": "This module deploys an Azure Container Registry (ACR) scopeMap."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "defaultValue": "[format('{0}-scopemaps', parameters('registryName'))]",
+                              "metadata": {
+                                "description": "Optional. The name of the scope map."
+                              }
+                            },
+                            "actions": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "description": "Required. The list of scoped permissions for registry artifacts."
+                              }
+                            },
+                            "description": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The user friendly description of the scope map."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "scopeMap": {
+                              "type": "Microsoft.ContainerRegistry/registries/scopeMaps",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "properties": {
+                                "actions": "[parameters('actions')]",
+                                "description": "[parameters('description')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the scope map."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the resource group the scope map was created in."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the scope map."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/scopeMaps', parameters('registryName'), parameters('name'))]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_replications": {
+                      "copy": {
+                        "name": "registry_replications",
+                        "count": "[length(coalesce(parameters('replications'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Registry-Replication-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(parameters('replications'), createArray())[copyIndex()].name]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "location": {
+                            "value": "[coalesce(parameters('replications'), createArray())[copyIndex()].location]"
+                          },
+                          "regionEndpointEnabled": {
+                            "value": "[tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'regionEndpointEnabled')]"
+                          },
+                          "zoneRedundancy": {
+                            "value": "[tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'zoneRedundancy')]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('replications'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "6036875058945996178"
+                            },
+                            "name": "Azure Container Registry (ACR) Replications",
+                            "description": "This module deploys an Azure Container Registry (ACR) Replication."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the replication."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all resources."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Tags of the resource."
+                              }
+                            },
+                            "regionEndpointEnabled": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Specifies whether the replication regional endpoint is enabled. Requests will not be routed to a replication whose regional endpoint is disabled, however its data will continue to be synced with other replications."
+                              }
+                            },
+                            "zoneRedundancy": {
+                              "type": "string",
+                              "defaultValue": "Disabled",
+                              "allowedValues": [
+                                "Disabled",
+                                "Enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. Whether or not zone redundancy is enabled for this container registry."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "replication": {
+                              "type": "Microsoft.ContainerRegistry/registries/replications",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "regionEndpointEnabled": "[parameters('regionEndpointEnabled')]",
+                                "zoneRedundancy": "[parameters('zoneRedundancy')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the replication."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the replication."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/replications', parameters('registryName'), parameters('name'))]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the resource group the replication was created in."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('replication', '2023-06-01-preview', 'full').location]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_credentialSets": {
+                      "copy": {
+                        "name": "registry_credentialSets",
+                        "count": "[length(coalesce(parameters('credentialSets'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Registry-CredentialSet-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].name]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "managedIdentities": {
+                            "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].managedIdentities]"
+                          },
+                          "authCredentials": {
+                            "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].authCredentials]"
+                          },
+                          "loginServer": {
+                            "value": "[coalesce(parameters('credentialSets'), createArray())[copyIndex()].loginServer]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "15848218260506856293"
+                            },
+                            "name": "Container Registries Credential Sets",
+                            "description": "This module deploys an ACR Credential Set."
+                          },
+                          "definitions": {
+                            "authCredentialsType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the credential."
+                                  }
+                                },
+                                "usernameSecretIdentifier": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. KeyVault Secret URI for accessing the username."
+                                  }
+                                },
+                                "passwordSecretIdentifier": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. KeyVault Secret URI for accessing the password."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true,
+                                "description": "The type for auth credentials."
+                              }
+                            },
+                            "managedIdentityOnlySysAssignedType": {
+                              "type": "object",
+                              "properties": {
+                                "systemAssigned": {
+                                  "type": "bool",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Enables system assigned managed identity on the resource."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a managed identity configuration. To be used if only system-assigned identities are supported by the resource provider.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The name of the credential set."
+                              }
+                            },
+                            "managedIdentities": {
+                              "$ref": "#/definitions/managedIdentityOnlySysAssignedType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The managed identity definition for this resource."
+                              }
+                            },
+                            "authCredentials": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/authCredentialsType"
+                              },
+                              "metadata": {
+                                "description": "Required. List of authentication credentials stored for an upstream. Usually consists of a primary and an optional secondary credential."
+                              }
+                            },
+                            "loginServer": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The credentials are stored for this upstream or login server."
+                              }
+                            }
+                          },
+                          "variables": {
+                            "identity": "[if(not(empty(parameters('managedIdentities'))), createObject('type', if(coalesce(tryGet(parameters('managedIdentities'), 'systemAssigned'), false()), 'SystemAssigned', null())), null())]"
+                          },
+                          "resources": {
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "credentialSet": {
+                              "type": "Microsoft.ContainerRegistry/registries/credentialSets",
+                              "apiVersion": "2023-11-01-preview",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "identity": "[variables('identity')]",
+                              "properties": {
+                                "authCredentials": "[parameters('authCredentials')]",
+                                "loginServer": "[parameters('loginServer')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The Name of the Credential Set."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the Credential Set."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the Credential Set."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/credentialSets', parameters('registryName'), parameters('name'))]"
+                            },
+                            "systemAssignedMIPrincipalId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "The principal ID of the system assigned identity."
+                              },
+                              "value": "[tryGet(tryGet(reference('credentialSet', '2023-11-01-preview', 'full'), 'identity'), 'principalId')]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_cacheRules": {
+                      "copy": {
+                        "name": "registry_cacheRules",
+                        "count": "[length(coalesce(parameters('cacheRules'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Registry-Cache-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "sourceRepository": {
+                            "value": "[coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository]"
+                          },
+                          "name": {
+                            "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'name')]"
+                          },
+                          "targetRepository": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'targetRepository'), coalesce(parameters('cacheRules'), createArray())[copyIndex()].sourceRepository)]"
+                          },
+                          "credentialSetResourceId": {
+                            "value": "[tryGet(coalesce(parameters('cacheRules'), createArray())[copyIndex()], 'credentialSetResourceId')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "3783697279882479947"
+                            },
+                            "name": "Container Registries Cache",
+                            "description": "Cache for Azure Container Registry (Preview) feature allows users to cache container images in a private container registry. Cache for ACR, is a preview feature available in Basic, Standard, and Premium service tiers ([ref](https://learn.microsoft.com/en-us/azure/container-registry/tutorial-registry-cache))."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "defaultValue": "[replace(replace(replace(parameters('sourceRepository'), '/', '-'), '.', '-'), '*', '')]",
+                              "metadata": {
+                                "description": "Optional. The name of the cache rule. Will be derived from the source repository name if not defined."
+                              }
+                            },
+                            "sourceRepository": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Source repository pulled from upstream."
+                              }
+                            },
+                            "targetRepository": {
+                              "type": "string",
+                              "defaultValue": "[parameters('sourceRepository')]",
+                              "metadata": {
+                                "description": "Optional. Target repository specified in docker pull command. E.g.: docker pull myregistry.azurecr.io/{targetRepository}:{tag}."
+                              }
+                            },
+                            "credentialSetResourceId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The resource ID of the credential store which is associated with the cache rule."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "cacheRule": {
+                              "type": "Microsoft.ContainerRegistry/registries/cacheRules",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "properties": {
+                                "sourceRepository": "[parameters('sourceRepository')]",
+                                "targetRepository": "[parameters('targetRepository')]",
+                                "credentialSetResourceId": "[parameters('credentialSetResourceId')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The Name of the Cache Rule."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the Cache Rule."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the Cache Rule."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/cacheRules', parameters('registryName'), parameters('name'))]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry",
+                        "registry_credentialSets"
+                      ]
+                    },
+                    "registry_webhooks": {
+                      "copy": {
+                        "name": "registry_webhooks",
+                        "count": "[length(coalesce(parameters('webhooks'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-Registry-Webhook-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(parameters('webhooks'), createArray())[copyIndex()].name]"
+                          },
+                          "registryName": {
+                            "value": "[parameters('name')]"
+                          },
+                          "location": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'location'), parameters('location'))]"
+                          },
+                          "action": {
+                            "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'action')]"
+                          },
+                          "customHeaders": {
+                            "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'customHeaders')]"
+                          },
+                          "scope": {
+                            "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'scope')]"
+                          },
+                          "status": {
+                            "value": "[tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'status')]"
+                          },
+                          "serviceUri": {
+                            "value": "[coalesce(parameters('webhooks'), createArray())[copyIndex()].serviceUri]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('webhooks'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.93.31351",
+                              "templateHash": "10084997815751263562"
+                            },
+                            "name": "Azure Container Registry (ACR) Webhooks",
+                            "description": "This module deploys an Azure Container Registry (ACR) Webhook."
+                          },
+                          "parameters": {
+                            "registryName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Conditional. The name of the parent registry. Required if the template is used in a standalone deployment."
+                              }
+                            },
+                            "name": {
+                              "type": "string",
+                              "defaultValue": "[format('{0}webhook', parameters('registryName'))]",
+                              "minLength": 5,
+                              "maxLength": 50,
+                              "metadata": {
+                                "description": "Optional. The name of the registry webhook."
+                              }
+                            },
+                            "serviceUri": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. The service URI for the webhook to post notifications."
+                              }
+                            },
+                            "status": {
+                              "type": "string",
+                              "defaultValue": "enabled",
+                              "allowedValues": [
+                                "disabled",
+                                "enabled"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The status of the webhook at the time the operation was called."
+                              }
+                            },
+                            "action": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "defaultValue": [
+                                "chart_delete",
+                                "chart_push",
+                                "delete",
+                                "push",
+                                "quarantine"
+                              ],
+                              "metadata": {
+                                "description": "Optional. The list of actions that trigger the webhook to post notifications."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all resources."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Tags of the resource."
+                              }
+                            },
+                            "customHeaders": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Custom headers that will be added to the webhook notifications."
+                              }
+                            },
+                            "scope": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The scope of repositories where the event can be triggered. For example, 'foo:*' means events for all tags under repository 'foo'. 'foo:bar' means events for 'foo:bar' only. 'foo' is equivalent to 'foo:latest'. Empty means all events."
+                              }
+                            }
+                          },
+                          "resources": {
+                            "registry": {
+                              "existing": true,
+                              "type": "Microsoft.ContainerRegistry/registries",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[parameters('registryName')]"
+                            },
+                            "webhook": {
+                              "type": "Microsoft.ContainerRegistry/registries/webhooks",
+                              "apiVersion": "2023-06-01-preview",
+                              "name": "[format('{0}/{1}', parameters('registryName'), parameters('name'))]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "actions": "[parameters('action')]",
+                                "customHeaders": "[parameters('customHeaders')]",
+                                "scope": "[parameters('scope')]",
+                                "serviceUri": "[parameters('serviceUri')]",
+                                "status": "[parameters('status')]"
+                              }
+                            }
+                          },
+                          "outputs": {
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the webhook."
+                              },
+                              "value": "[resourceId('Microsoft.ContainerRegistry/registries/webhooks', parameters('registryName'), parameters('name'))]"
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the webhook."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the Azure container registry."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "actions": {
+                              "type": "array",
+                              "metadata": {
+                                "description": "The actions of the webhook."
+                              },
+                              "value": "[reference('webhook').actions]"
+                            },
+                            "status": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The status of the webhook."
+                              },
+                              "value": "[reference('webhook').status]"
+                            },
+                            "provistioningState": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The provisioning state of the webhook."
+                              },
+                              "value": "[reference('webhook').provisioningState]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('webhook', '2023-06-01-preview', 'full').location]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry"
+                      ]
+                    },
+                    "registry_privateEndpoints": {
+                      "copy": {
+                        "name": "registry_privateEndpoints",
+                        "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]"
+                      },
+                      "type": "Microsoft.Resources/deployments",
+                      "apiVersion": "2022-09-01",
+                      "name": "[format('{0}-registry-PrivateEndpoint-{1}', uniqueString(deployment().name, parameters('location')), copyIndex())]",
+                      "subscriptionId": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[2]]",
+                      "resourceGroup": "[split(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'resourceGroupResourceId'), resourceGroup().id), '/')[4]]",
+                      "properties": {
+                        "expressionEvaluationOptions": {
+                          "scope": "inner"
+                        },
+                        "mode": "Incremental",
+                        "parameters": {
+                          "name": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'name'), format('pep-{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex()))]"
+                          },
+                          "privateLinkServiceConnections": "[if(not(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true())), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry')))))), createObject('value', null()))]",
+                          "manualPrivateLinkServiceConnections": "[if(equals(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'isManualConnection'), true()), createObject('value', createArray(createObject('name', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateLinkServiceConnectionName'), format('{0}-{1}-{2}', last(split(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '/')), coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry'), copyIndex())), 'properties', createObject('privateLinkServiceId', resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), 'groupIds', createArray(coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'service'), 'registry')), 'requestMessage', coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'manualConnectionRequestMessage'), 'Manual approval required.'))))), createObject('value', null()))]",
+                          "subnetResourceId": {
+                            "value": "[coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId]"
+                          },
+                          "enableTelemetry": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'enableTelemetry'), parameters('enableTelemetry'))]"
+                          },
+                          "location": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'location'), reference(split(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()].subnetResourceId, '/subnets/')[0], '2020-06-01', 'Full').location)]"
+                          },
+                          "lock": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'lock'), parameters('lock'))]"
+                          },
+                          "privateDnsZoneGroup": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'privateDnsZoneGroup')]"
+                          },
+                          "roleAssignments": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'roleAssignments')]"
+                          },
+                          "tags": {
+                            "value": "[coalesce(tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'tags'), parameters('tags'))]"
+                          },
+                          "customDnsConfigs": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customDnsConfigs')]"
+                          },
+                          "ipConfigurations": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'ipConfigurations')]"
+                          },
+                          "applicationSecurityGroupResourceIds": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'applicationSecurityGroupResourceIds')]"
+                          },
+                          "customNetworkInterfaceName": {
+                            "value": "[tryGet(coalesce(parameters('privateEndpoints'), createArray())[copyIndex()], 'customNetworkInterfaceName')]"
+                          }
+                        },
+                        "template": {
+                          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                          "languageVersion": "2.0",
+                          "contentVersion": "1.0.0.0",
+                          "metadata": {
+                            "_generator": {
+                              "name": "bicep",
+                              "version": "0.33.13.18514",
+                              "templateHash": "15954548978129725136"
+                            },
+                            "name": "Private Endpoints",
+                            "description": "This module deploys a Private Endpoint."
+                          },
+                          "definitions": {
+                            "privateDnsZoneGroupType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the Private DNS Zone Group."
+                                  }
+                                },
+                                "privateDnsZoneGroupConfigs": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                  },
+                                  "metadata": {
+                                    "description": "Required. The private DNS zone groups to associate the private endpoint. A DNS zone group can support up to 5 DNS zones."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true
+                              }
+                            },
+                            "ipConfigurationType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the resource that is unique within a resource group."
+                                  }
+                                },
+                                "properties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "groupId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                                      }
+                                    },
+                                    "memberName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The member name of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string."
+                                      }
+                                    },
+                                    "privateIPAddress": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. A private IP address obtained from the private endpoint's subnet."
+                                      }
+                                    }
+                                  },
+                                  "metadata": {
+                                    "description": "Required. Properties of private endpoint IP configurations."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true
+                              }
+                            },
+                            "privateLinkServiceConnectionType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The name of the private link service connection."
+                                  }
+                                },
+                                "properties": {
+                                  "type": "object",
+                                  "properties": {
+                                    "groupIds": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "metadata": {
+                                        "description": "Required. The ID of a group obtained from the remote resource that this private endpoint should connect to. If used with private link service connection, this property must be defined as empty string array `[]`."
+                                      }
+                                    },
+                                    "privateLinkServiceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Required. The resource id of private link service."
+                                      }
+                                    },
+                                    "requestMessage": {
+                                      "type": "string",
+                                      "nullable": true,
+                                      "metadata": {
+                                        "description": "Optional. A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
+                                      }
+                                    }
+                                  },
+                                  "metadata": {
+                                    "description": "Required. Properties of private link service connection."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true
+                              }
+                            },
+                            "customDnsConfigType": {
+                              "type": "object",
+                              "properties": {
+                                "fqdn": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. FQDN that resolves to private endpoint IP address."
+                                  }
+                                },
+                                "ipAddresses": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "metadata": {
+                                    "description": "Required. A list of private IP addresses of the private endpoint."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_export!": true
+                              }
+                            },
+                            "lockType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the name of lock."
+                                  }
+                                },
+                                "kind": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "CanNotDelete",
+                                    "None",
+                                    "ReadOnly"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Specify the type of lock."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a lock.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            },
+                            "privateDnsZoneGroupConfigType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name of the private DNS zone group config."
+                                  }
+                                },
+                                "privateDnsZoneResourceId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The resource id of the private DNS zone."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "private-dns-zone-group/main.bicep"
+                                }
+                              }
+                            },
+                            "roleAssignmentType": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The name (as GUID) of the role assignment. If not provided, a GUID will be generated."
+                                  }
+                                },
+                                "roleDefinitionIdOrName": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The role to assign. You can provide either the display name of the role definition, the role definition GUID, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'."
+                                  }
+                                },
+                                "principalId": {
+                                  "type": "string",
+                                  "metadata": {
+                                    "description": "Required. The principal ID of the principal (user/group/identity) to assign the role to."
+                                  }
+                                },
+                                "principalType": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "Device",
+                                    "ForeignGroup",
+                                    "Group",
+                                    "ServicePrincipal",
+                                    "User"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The principal type of the assigned principal ID."
+                                  }
+                                },
+                                "description": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The description of the role assignment."
+                                  }
+                                },
+                                "condition": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The conditions on the role assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase \"foo_storage_container\"."
+                                  }
+                                },
+                                "conditionVersion": {
+                                  "type": "string",
+                                  "allowedValues": [
+                                    "2.0"
+                                  ],
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. Version of the condition."
+                                  }
+                                },
+                                "delegatedManagedIdentityResourceId": {
+                                  "type": "string",
+                                  "nullable": true,
+                                  "metadata": {
+                                    "description": "Optional. The Resource Id of the delegated managed identity resource."
+                                  }
+                                }
+                              },
+                              "metadata": {
+                                "description": "An AVM-aligned type for a role assignment.",
+                                "__bicep_imported_from!": {
+                                  "sourceTemplate": "br:mcr.microsoft.com/bicep/avm/utl/types/avm-common-types:0.5.1"
+                                }
+                              }
+                            }
+                          },
+                          "parameters": {
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Name of the private endpoint resource to create."
+                              }
+                            },
+                            "subnetResourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "Required. Resource ID of the subnet where the endpoint needs to be created."
+                              }
+                            },
+                            "applicationSecurityGroupResourceIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Application security groups in which the private endpoint IP configuration is included."
+                              }
+                            },
+                            "customNetworkInterfaceName": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The custom name of the network interface attached to the private endpoint."
+                              }
+                            },
+                            "ipConfigurations": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/ipConfigurationType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. A list of IP configurations of the private endpoint. This will be used to map to the First Party Service endpoints."
+                              }
+                            },
+                            "privateDnsZoneGroup": {
+                              "$ref": "#/definitions/privateDnsZoneGroupType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The private DNS zone group to configure for the private endpoint."
+                              }
+                            },
+                            "location": {
+                              "type": "string",
+                              "defaultValue": "[resourceGroup().location]",
+                              "metadata": {
+                                "description": "Optional. Location for all Resources."
+                              }
+                            },
+                            "lock": {
+                              "$ref": "#/definitions/lockType",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. The lock settings of the service."
+                              }
+                            },
+                            "roleAssignments": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/roleAssignmentType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Array of role assignments to create."
+                              }
+                            },
+                            "tags": {
+                              "type": "object",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Tags to be applied on all resources/resource groups in this deployment."
+                              }
+                            },
+                            "customDnsConfigs": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/customDnsConfigType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Optional. Custom DNS configurations."
+                              }
+                            },
+                            "manualPrivateLinkServiceConnections": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/privateLinkServiceConnectionType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Conditional. A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource. Required if `privateLinkServiceConnections` is empty."
+                              }
+                            },
+                            "privateLinkServiceConnections": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/privateLinkServiceConnectionType"
+                              },
+                              "nullable": true,
+                              "metadata": {
+                                "description": "Conditional. A grouping of information about the connection to the remote resource. Required if `manualPrivateLinkServiceConnections` is empty."
+                              }
+                            },
+                            "enableTelemetry": {
+                              "type": "bool",
+                              "defaultValue": true,
+                              "metadata": {
+                                "description": "Optional. Enable/Disable usage telemetry for module."
+                              }
+                            }
+                          },
+                          "variables": {
+                            "copy": [
+                              {
+                                "name": "formattedRoleAssignments",
+                                "count": "[length(coalesce(parameters('roleAssignments'), createArray()))]",
+                                "input": "[union(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')], createObject('roleDefinitionId', coalesce(tryGet(variables('builtInRoleNames'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName), if(contains(coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, '/providers/Microsoft.Authorization/roleDefinitions/'), coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', coalesce(parameters('roleAssignments'), createArray())[copyIndex('formattedRoleAssignments')].roleDefinitionIdOrName)))))]"
+                              }
+                            ],
+                            "builtInRoleNames": {
+                              "Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+                              "DNS Resolver Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '0f2ebee7-ffd4-4fc0-b3b7-664099fdad5d')]",
+                              "DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'befefa01-2a29-4197-83a8-272ff33ce314')]",
+                              "Domain Services Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'eeaeda52-9324-47f6-8069-5d5bade478b2')]",
+                              "Domain Services Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '361898ef-9ed1-48c2-849c-a832951106bb')]",
+                              "Network Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+                              "Owner": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+                              "Private DNS Zone Contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b12aa53e-6015-4669-85d0-8515ebb3ae7f')]",
+                              "Reader": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'acdd72a7-3385-48ef-bd42-f606fba81ae7')]",
+                              "Role Based Access Control Administrator": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'f58310d9-a9f6-439a-9e8d-f62e7b41a168')]"
+                            }
+                          },
+                          "resources": {
+                            "avmTelemetry": {
+                              "condition": "[parameters('enableTelemetry')]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2024-03-01",
+                              "name": "[format('46d3xbcp.res.network-privateendpoint.{0}.{1}', replace('0.10.1', '.', '-'), substring(uniqueString(deployment().name, parameters('location')), 0, 4))]",
+                              "properties": {
+                                "mode": "Incremental",
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "contentVersion": "1.0.0.0",
+                                  "resources": [],
+                                  "outputs": {
+                                    "telemetry": {
+                                      "type": "String",
+                                      "value": "For more information, see https://aka.ms/avm/TelemetryInfo"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "privateEndpoint": {
+                              "type": "Microsoft.Network/privateEndpoints",
+                              "apiVersion": "2023-11-01",
+                              "name": "[parameters('name')]",
+                              "location": "[parameters('location')]",
+                              "tags": "[parameters('tags')]",
+                              "properties": {
+                                "copy": [
+                                  {
+                                    "name": "applicationSecurityGroups",
+                                    "count": "[length(coalesce(parameters('applicationSecurityGroupResourceIds'), createArray()))]",
+                                    "input": {
+                                      "id": "[coalesce(parameters('applicationSecurityGroupResourceIds'), createArray())[copyIndex('applicationSecurityGroups')]]"
+                                    }
+                                  }
+                                ],
+                                "customDnsConfigs": "[coalesce(parameters('customDnsConfigs'), createArray())]",
+                                "customNetworkInterfaceName": "[coalesce(parameters('customNetworkInterfaceName'), '')]",
+                                "ipConfigurations": "[coalesce(parameters('ipConfigurations'), createArray())]",
+                                "manualPrivateLinkServiceConnections": "[coalesce(parameters('manualPrivateLinkServiceConnections'), createArray())]",
+                                "privateLinkServiceConnections": "[coalesce(parameters('privateLinkServiceConnections'), createArray())]",
+                                "subnet": {
+                                  "id": "[parameters('subnetResourceId')]"
+                                }
+                              }
+                            },
+                            "privateEndpoint_lock": {
+                              "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
+                              "type": "Microsoft.Authorization/locks",
+                              "apiVersion": "2020-05-01",
+                              "scope": "[format('Microsoft.Network/privateEndpoints/{0}', parameters('name'))]",
+                              "name": "[coalesce(tryGet(parameters('lock'), 'name'), format('lock-{0}', parameters('name')))]",
+                              "properties": {
+                                "level": "[coalesce(tryGet(parameters('lock'), 'kind'), '')]",
+                                "notes": "[if(equals(tryGet(parameters('lock'), 'kind'), 'CanNotDelete'), 'Cannot delete resource or child resources.', 'Cannot delete or modify the resource or child resources.')]"
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            },
+                            "privateEndpoint_roleAssignments": {
+                              "copy": {
+                                "name": "privateEndpoint_roleAssignments",
+                                "count": "[length(coalesce(variables('formattedRoleAssignments'), createArray()))]"
+                              },
+                              "type": "Microsoft.Authorization/roleAssignments",
+                              "apiVersion": "2022-04-01",
+                              "scope": "[format('Microsoft.Network/privateEndpoints/{0}', parameters('name'))]",
+                              "name": "[coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'name'), guid(resourceId('Microsoft.Network/privateEndpoints', parameters('name')), coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId, coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId))]",
+                              "properties": {
+                                "roleDefinitionId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].roleDefinitionId]",
+                                "principalId": "[coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()].principalId]",
+                                "description": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'description')]",
+                                "principalType": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'principalType')]",
+                                "condition": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition')]",
+                                "conditionVersion": "[if(not(empty(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'condition'))), coalesce(tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'conditionVersion'), '2.0'), null())]",
+                                "delegatedManagedIdentityResourceId": "[tryGet(coalesce(variables('formattedRoleAssignments'), createArray())[copyIndex()], 'delegatedManagedIdentityResourceId')]"
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            },
+                            "privateEndpoint_privateDnsZoneGroup": {
+                              "condition": "[not(empty(parameters('privateDnsZoneGroup')))]",
+                              "type": "Microsoft.Resources/deployments",
+                              "apiVersion": "2022-09-01",
+                              "name": "[format('{0}-PrivateEndpoint-PrivateDnsZoneGroup', uniqueString(deployment().name))]",
+                              "properties": {
+                                "expressionEvaluationOptions": {
+                                  "scope": "inner"
+                                },
+                                "mode": "Incremental",
+                                "parameters": {
+                                  "name": {
+                                    "value": "[tryGet(parameters('privateDnsZoneGroup'), 'name')]"
+                                  },
+                                  "privateEndpointName": {
+                                    "value": "[parameters('name')]"
+                                  },
+                                  "privateDnsZoneConfigs": {
+                                    "value": "[parameters('privateDnsZoneGroup').privateDnsZoneGroupConfigs]"
+                                  }
+                                },
+                                "template": {
+                                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                                  "languageVersion": "2.0",
+                                  "contentVersion": "1.0.0.0",
+                                  "metadata": {
+                                    "_generator": {
+                                      "name": "bicep",
+                                      "version": "0.33.13.18514",
+                                      "templateHash": "5440815542537978381"
+                                    },
+                                    "name": "Private Endpoint Private DNS Zone Groups",
+                                    "description": "This module deploys a Private Endpoint Private DNS Zone Group."
+                                  },
+                                  "definitions": {
+                                    "privateDnsZoneGroupConfigType": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string",
+                                          "nullable": true,
+                                          "metadata": {
+                                            "description": "Optional. The name of the private DNS zone group config."
+                                          }
+                                        },
+                                        "privateDnsZoneResourceId": {
+                                          "type": "string",
+                                          "metadata": {
+                                            "description": "Required. The resource id of the private DNS zone."
+                                          }
+                                        }
+                                      },
+                                      "metadata": {
+                                        "__bicep_export!": true
+                                      }
+                                    }
+                                  },
+                                  "parameters": {
+                                    "privateEndpointName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "Conditional. The name of the parent private endpoint. Required if the template is used in a standalone deployment."
+                                      }
+                                    },
+                                    "privateDnsZoneConfigs": {
+                                      "type": "array",
+                                      "items": {
+                                        "$ref": "#/definitions/privateDnsZoneGroupConfigType"
+                                      },
+                                      "minLength": 1,
+                                      "maxLength": 5,
+                                      "metadata": {
+                                        "description": "Required. Array of private DNS zone configurations of the private DNS zone group. A DNS zone group can support up to 5 DNS zones."
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "defaultValue": "default",
+                                      "metadata": {
+                                        "description": "Optional. The name of the private DNS zone group."
+                                      }
+                                    }
+                                  },
+                                  "variables": {
+                                    "copy": [
+                                      {
+                                        "name": "privateDnsZoneConfigsVar",
+                                        "count": "[length(parameters('privateDnsZoneConfigs'))]",
+                                        "input": {
+                                          "name": "[coalesce(tryGet(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')], 'name'), last(split(parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')].privateDnsZoneResourceId, '/')))]",
+                                          "properties": {
+                                            "privateDnsZoneId": "[parameters('privateDnsZoneConfigs')[copyIndex('privateDnsZoneConfigsVar')].privateDnsZoneResourceId]"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "resources": {
+                                    "privateEndpoint": {
+                                      "existing": true,
+                                      "type": "Microsoft.Network/privateEndpoints",
+                                      "apiVersion": "2023-11-01",
+                                      "name": "[parameters('privateEndpointName')]"
+                                    },
+                                    "privateDnsZoneGroup": {
+                                      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+                                      "apiVersion": "2023-11-01",
+                                      "name": "[format('{0}/{1}', parameters('privateEndpointName'), parameters('name'))]",
+                                      "properties": {
+                                        "privateDnsZoneConfigs": "[variables('privateDnsZoneConfigsVar')]"
+                                      }
+                                    }
+                                  },
+                                  "outputs": {
+                                    "name": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The name of the private endpoint DNS zone group."
+                                      },
+                                      "value": "[parameters('name')]"
+                                    },
+                                    "resourceId": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource ID of the private endpoint DNS zone group."
+                                      },
+                                      "value": "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', parameters('privateEndpointName'), parameters('name'))]"
+                                    },
+                                    "resourceGroupName": {
+                                      "type": "string",
+                                      "metadata": {
+                                        "description": "The resource group the private endpoint DNS zone group was deployed into."
+                                      },
+                                      "value": "[resourceGroup().name]"
+                                    }
+                                  }
+                                }
+                              },
+                              "dependsOn": [
+                                "privateEndpoint"
+                              ]
+                            }
+                          },
+                          "outputs": {
+                            "resourceGroupName": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource group the private endpoint was deployed into."
+                              },
+                              "value": "[resourceGroup().name]"
+                            },
+                            "resourceId": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The resource ID of the private endpoint."
+                              },
+                              "value": "[resourceId('Microsoft.Network/privateEndpoints', parameters('name'))]"
+                            },
+                            "name": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The name of the private endpoint."
+                              },
+                              "value": "[parameters('name')]"
+                            },
+                            "location": {
+                              "type": "string",
+                              "metadata": {
+                                "description": "The location the resource was deployed into."
+                              },
+                              "value": "[reference('privateEndpoint', '2023-11-01', 'full').location]"
+                            },
+                            "customDnsConfigs": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/definitions/customDnsConfigType"
+                              },
+                              "metadata": {
+                                "description": "The custom DNS configurations of the private endpoint."
+                              },
+                              "value": "[reference('privateEndpoint').customDnsConfigs]"
+                            },
+                            "networkInterfaceResourceIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "metadata": {
+                                "description": "The resource IDs of the network interfaces associated with the private endpoint."
+                              },
+                              "value": "[map(reference('privateEndpoint').networkInterfaces, lambda('nic', lambdaVariables('nic').id))]"
+                            },
+                            "groupId": {
+                              "type": "string",
+                              "nullable": true,
+                              "metadata": {
+                                "description": "The group Id for the private endpoint Group."
+                              },
+                              "value": "[coalesce(tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'manualPrivateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0), tryGet(tryGet(tryGet(tryGet(reference('privateEndpoint'), 'privateLinkServiceConnections'), 0, 'properties'), 'groupIds'), 0))]"
+                            }
+                          }
+                        }
+                      },
+                      "dependsOn": [
+                        "registry",
+                        "registry_replications"
+                      ]
+                    }
+                  },
+                  "outputs": {
+                    "name": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The Name of the Azure container registry."
+                      },
+                      "value": "[parameters('name')]"
+                    },
+                    "loginServer": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The reference to the Azure container registry."
+                      },
+                      "value": "[reference(resourceId('Microsoft.ContainerRegistry/registries', parameters('name')), '2019-05-01').loginServer]"
+                    },
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The name of the Azure container registry."
+                      },
+                      "value": "[resourceGroup().name]"
+                    },
+                    "resourceId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The resource ID of the Azure container registry."
+                      },
+                      "value": "[resourceId('Microsoft.ContainerRegistry/registries', parameters('name'))]"
+                    },
+                    "systemAssignedMIPrincipalId": {
+                      "type": "string",
+                      "nullable": true,
+                      "metadata": {
+                        "description": "The principal ID of the system assigned identity."
+                      },
+                      "value": "[tryGet(tryGet(reference('registry', '2023-06-01-preview', 'full'), 'identity'), 'principalId')]"
+                    },
+                    "location": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "The location the resource was deployed into."
+                      },
+                      "value": "[reference('registry', '2023-06-01-preview', 'full').location]"
+                    },
+                    "credentialSetsSystemAssignedMIPrincipalIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The Principal IDs of the ACR Credential Sets system-assigned identities."
+                      },
+                      "copy": {
+                        "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                        "input": "[tryGet(tryGet(reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs, 'systemAssignedMIPrincipalId'), 'value')]"
+                      }
+                    },
+                    "credentialSetsResourceIds": {
+                      "type": "array",
+                      "metadata": {
+                        "description": "The Resource IDs of the ACR Credential Sets."
+                      },
+                      "copy": {
+                        "count": "[length(range(0, length(coalesce(parameters('credentialSets'), createArray()))))]",
+                        "input": "[reference(format('registry_credentialSets[{0}]', range(0, length(coalesce(parameters('credentialSets'), createArray())))[copyIndex()])).outputs.resourceId.value]"
+                      }
+                    },
+                    "privateEndpoints": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/privateEndpointOutputType"
+                      },
+                      "metadata": {
+                        "description": "The private endpoints of the Azure container registry."
+                      },
+                      "copy": {
+                        "count": "[length(coalesce(parameters('privateEndpoints'), createArray()))]",
+                        "input": {
+                          "name": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.name.value]",
+                          "resourceId": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.resourceId.value]",
+                          "groupId": "[tryGet(tryGet(reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs, 'groupId'), 'value')]",
+                          "customDnsConfigs": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.customDnsConfigs.value]",
+                          "networkInterfaceResourceIds": "[reference(format('registry_privateEndpoints[{0}]', copyIndex())).outputs.networkInterfaceResourceIds.value]"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "outputs": {
+            "name": {
+              "type": "string",
+              "metadata": {
+                "description": "The name of the Container Registry."
+              },
+              "value": "[reference('containerRegistry').outputs.name.value]"
+            },
+            "resourceId": {
+              "type": "string",
+              "metadata": {
+                "description": "The resource ID of the Container Registry."
+              },
+              "value": "[reference('containerRegistry').outputs.resourceId.value]"
+            },
+            "loginServer": {
+              "type": "string",
+              "metadata": {
+                "description": "The login server URL of the Container Registry."
+              },
+              "value": "[reference('containerRegistry').outputs.loginServer.value]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "userAssignedIdentity"
+      ]
     },
     "virtualNetwork": {
       "condition": "[parameters('enablePrivateNetworking')]",
@@ -43567,15 +46827,17 @@
           },
           "siteConfig": {
             "value": {
-              "linuxFxVersion": "[format('DOCKER|{0}.azurecr.io/content-gen-app:{1}', variables('acrResourceName'), parameters('imageTag'))]",
+              "linuxFxVersion": "DOCKER|mcr.microsoft.com/azuredocs/aci-helloworld:latest",
               "minTlsVersion": "1.2",
               "alwaysOn": true,
-              "ftpsState": "FtpsOnly"
+              "ftpsState": "FtpsOnly",
+              "acrUseManagedIdentityCreds": true,
+              "acrUserManagedIdentityID": "[reference('userAssignedIdentity').outputs.clientId.value]"
             }
           },
           "virtualNetworkSubnetId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.webSubnetResourceId.value), createObject('value', null()))]",
           "configs": {
-            "value": "[concat(createArray(createObject('name', 'appsettings', 'properties', createObject('DOCKER_REGISTRY_SERVER_URL', format('https://{0}.azurecr.io', variables('acrResourceName')), 'BACKEND_URL', if(parameters('enablePrivateNetworking'), format('http://{0}:8000', reference('containerInstance').outputs.ipAddress.value), format('http://{0}:8000', reference('containerInstance').outputs.fqdn.value)), 'AZURE_CLIENT_ID', reference('userAssignedIdentity').outputs.clientId.value), 'applicationInsightResourceId', if(parameters('enableMonitoring'), reference('applicationInsights').outputs.resourceId.value, null()))), if(parameters('enableMonitoring'), createArray(createObject('name', 'logs', 'properties', createObject())), createArray()))]"
+            "value": "[concat(createArray(createObject('name', 'appsettings', 'properties', createObject('DOCKER_REGISTRY_SERVER_URL', format('https://{0}', reference('containerRegistry').outputs.loginServer.value), 'BACKEND_URL', if(parameters('enablePrivateNetworking'), format('http://{0}:8000', reference('containerInstance').outputs.ipAddress.value), format('http://{0}:8000', reference('containerInstance').outputs.fqdn.value)), 'AZURE_CLIENT_ID', reference('userAssignedIdentity').outputs.clientId.value), 'applicationInsightResourceId', if(parameters('enableMonitoring'), reference('applicationInsights').outputs.resourceId.value, null()))), if(parameters('enableMonitoring'), createArray(createObject('name', 'logs', 'properties', createObject())), createArray()))]"
           },
           "enableMonitoring": {
             "value": "[parameters('enableMonitoring')]"
@@ -45529,6 +48791,7 @@
       "dependsOn": [
         "applicationInsights",
         "containerInstance",
+        "containerRegistry",
         "logAnalyticsWorkspace",
         "userAssignedIdentity",
         "virtualNetwork",
@@ -45555,7 +48818,7 @@
             "value": "[parameters('tags')]"
           },
           "containerImage": {
-            "value": "[format('{0}.azurecr.io/content-gen-api:{1}', variables('acrResourceName'), parameters('imageTag'))]"
+            "value": "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
           },
           "cpu": {
             "value": 2
@@ -45569,6 +48832,9 @@
           "subnetResourceId": "[if(parameters('enablePrivateNetworking'), createObject('value', reference('virtualNetwork').outputs.aciSubnetResourceId.value), createObject('value', ''))]",
           "userAssignedIdentityResourceId": {
             "value": "[reference('userAssignedIdentity').outputs.resourceId.value]"
+          },
+          "acrLoginServer": {
+            "value": "[reference('containerRegistry').outputs.loginServer.value]"
           },
           "enableTelemetry": {
             "value": "[parameters('enableTelemetry')]"
@@ -45693,7 +48959,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "3218681246740688998"
+              "templateHash": "9581263247326965160"
             }
           },
           "parameters": {
@@ -45768,6 +49034,13 @@
               "metadata": {
                 "description": "Required. User-assigned managed identity resource ID for ACR pull."
               }
+            },
+            "acrLoginServer": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Optional. ACR login server (e.g. myregistry.azurecr.io). When set, the container group pulls the image using the user-assigned managed identity."
+              }
             }
           },
           "variables": {
@@ -45834,7 +49107,8 @@
                     }
                   ],
                   "dnsNameLabel": "[if(variables('isPrivateNetworking'), null(), parameters('name'))]"
-                }
+                },
+                "imageRegistryCredentials": "[if(not(empty(parameters('acrLoginServer'))), createArray(createObject('server', parameters('acrLoginServer'), 'identity', parameters('userAssignedIdentityResourceId'))), null())]"
               }
             }
           ],
@@ -45873,6 +49147,7 @@
       "dependsOn": [
         "aiFoundryAiServicesProject",
         "applicationInsights",
+        "containerRegistry",
         "userAssignedIdentity",
         "virtualNetwork"
       ]
@@ -46073,7 +49348,7 @@
       "metadata": {
         "description": "Contains ACR Name"
       },
-      "value": "[variables('acrResourceName')]"
+      "value": "[reference('containerRegistry').outputs.name.value]"
     },
     "USE_FOUNDRY": {
       "type": "bool",

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -40,12 +40,6 @@
     },
     "azureExistingAIProjectResourceId": {
       "value": "${AZURE_EXISTING_AIPROJECT_RESOURCE_ID}"
-    },
-    "acrName": {
-      "value": "${AZURE_ENV_CONTAINER_REGISTRY_NAME}"
-    },
-    "imageTag": {
-      "value": "${AZURE_ENV_IMAGE_TAG=latest}"
     }
   }
 }

--- a/infra/main.waf.parameters.json
+++ b/infra/main.waf.parameters.json
@@ -41,12 +41,6 @@
     "azureExistingAIProjectResourceId": {
       "value": "${AZURE_EXISTING_AIPROJECT_RESOURCE_ID}"
     },
-    "acrName": {
-      "value": "${AZURE_ENV_CONTAINER_REGISTRY_NAME}"
-    },
-    "imageTag": {
-      "value": "${AZURE_ENV_IMAGE_TAG=latest}"
-    },
     "enablePrivateNetworking": {
       "value": true
     },

--- a/infra/modules/container-instance.bicep
+++ b/infra/modules/container-instance.bicep
@@ -34,6 +34,9 @@ param enableTelemetry bool = true
 @description('Required. User-assigned managed identity resource ID for ACR pull.')
 param userAssignedIdentityResourceId string
 
+@description('Optional. ACR login server (e.g. myregistry.azurecr.io). When set, the container group pulls the image using the user-assigned managed identity.')
+param acrLoginServer string = ''
+
 var isPrivateNetworking = !empty(subnetResourceId)
 
 // ============== //
@@ -102,8 +105,16 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2025-09-01'
       ]
       dnsNameLabel: isPrivateNetworking ? null : name
     }
-    // Removed imageRegistryCredentials - ACR is public with anonymous pull enabled
-    // If you need managed identity auth, add AcrPull role to the managed identity on the ACR
+    // Managed-identity based ACR authentication. Configured up-front so that when
+    // the placeholder image is later replaced with the private ACR image, the
+    // container group can authenticate to the registry using the user-assigned
+    // identity (which holds AcrPull). Unused while running a public image.
+    imageRegistryCredentials: !empty(acrLoginServer) ? [
+      {
+        server: acrLoginServer
+        identity: userAssignedIdentityResourceId
+      }
+    ] : null
   }
 }
 

--- a/infra/modules/container-registry.bicep
+++ b/infra/modules/container-registry.bicep
@@ -1,0 +1,91 @@
+// ========== container-registry.bicep ========== //
+// Azure Container Registry module.
+// Provisions an ACR and grants AcrPull to the frontend/backend identities so the
+// App Service and Container Instance can pull application images once they are
+// built and pushed by a post-deployment step.
+
+@description('Required. Name of the Azure Container Registry.')
+param name string
+
+@description('Optional. Location for the Container Registry.')
+param location string = resourceGroup().location
+
+@description('Optional. Tags for all resources.')
+param tags object = {}
+
+@description('Optional. Enable/Disable usage telemetry for module.')
+param enableTelemetry bool = true
+
+@description('Optional. SKU for the Container Registry.')
+@allowed([
+  'Basic'
+  'Standard'
+  'Premium'
+])
+param acrSku string = 'Standard'
+
+@description('Optional. Principal IDs (frontend/backend managed identities) that require AcrPull access.')
+param pullPrincipalIds array = []
+
+@description('Optional. Principal IDs (e.g. the deployer) that require AcrPush access to build and push images.')
+param pushPrincipalIds array = []
+
+@description('Optional. Principal type for the AcrPush role assignments.')
+@allowed([
+  'User'
+  'Group'
+  'ServicePrincipal'
+])
+param pushPrincipalType string = 'User'
+
+import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
+@description('Optional. The managed identity definition for this resource.')
+param managedIdentities managedIdentityAllType?
+
+// AcrPull role: allows the App Service / Container Instance identities to pull images.
+var acrPullRoleDefinitionId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+// AcrPush role: allows the deployer to build and push images to the registry.
+var acrPushRoleDefinitionId = '8311e382-0749-4cb8-b61a-304f252e45ec'
+
+var pullRoleAssignments = [
+  for principalId in pullPrincipalIds: {
+    principalId: principalId
+    roleDefinitionIdOrName: acrPullRoleDefinitionId
+    principalType: 'ServicePrincipal'
+  }
+]
+
+var pushRoleAssignments = [
+  for principalId in pushPrincipalIds: {
+    principalId: principalId
+    roleDefinitionIdOrName: acrPushRoleDefinitionId
+    principalType: pushPrincipalType
+  }
+]
+
+// ========== Azure Container Registry ========== //
+module containerRegistry 'br/public:avm/res/container-registry/registry:0.9.0' = {
+  name: take('avm.res.container-registry.registry.${name}', 64)
+  params: {
+    name: name
+    location: location
+    tags: tags
+    enableTelemetry: enableTelemetry
+    acrSku: acrSku
+    acrAdminUserEnabled: false
+    anonymousPullEnabled: false
+    publicNetworkAccess: 'Enabled'
+    networkRuleBypassOptions: 'AzureServices'
+    roleAssignments: concat(pullRoleAssignments, pushRoleAssignments)
+    managedIdentities: managedIdentities
+  }
+}
+
+@description('The name of the Container Registry.')
+output name string = containerRegistry.outputs.name
+
+@description('The resource ID of the Container Registry.')
+output resourceId string = containerRegistry.outputs.resourceId
+
+@description('The login server URL of the Container Registry.')
+output loginServer string = containerRegistry.outputs.loginServer

--- a/infra/modules/container-registry.bicep
+++ b/infra/modules/container-registry.bicep
@@ -38,6 +38,18 @@ param pushPrincipalIds array = []
 ])
 param pushPrincipalType string = 'User'
 
+@description('Optional. Enable private networking. Forces the Premium SKU, disables public network access and creates a private endpoint for the registry.')
+param enablePrivateNetworking bool = false
+
+@description('Optional. Enable scalability. Bumps the registry to the Premium SKU (WAF-aligned) to allow geo-replication and higher throughput.')
+param enableScalability bool = false
+
+@description('Optional. Resource ID of the subnet to host the registry private endpoint. Required when enablePrivateNetworking is true.')
+param privateEndpointSubnetResourceId string = ''
+
+@description('Optional. Resource ID of the privatelink.azurecr.io private DNS zone. Required when enablePrivateNetworking is true.')
+param privateDnsZoneResourceId string = ''
+
 import { managedIdentityAllType } from 'br/public:avm/utl/types/avm-common-types:0.7.0'
 @description('Optional. The managed identity definition for this resource.')
 param managedIdentities managedIdentityAllType?
@@ -46,6 +58,9 @@ param managedIdentities managedIdentityAllType?
 var acrPullRoleDefinitionId = '7f951dda-4ed3-4680-a7ca-43fe172d538d'
 // AcrPush role: allows the deployer to build and push images to the registry.
 var acrPushRoleDefinitionId = '8311e382-0749-4cb8-b61a-304f252e45ec'
+
+// Premium is required for private endpoints, and recommended (WAF) for scalability.
+var effectiveAcrSku = (enablePrivateNetworking || enableScalability) ? 'Premium' : acrSku
 
 var pullRoleAssignments = [
   for principalId in pullPrincipalIds: {
@@ -71,13 +86,35 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.9.0' =
     location: location
     tags: tags
     enableTelemetry: enableTelemetry
-    acrSku: acrSku
+    acrSku: effectiveAcrSku
     acrAdminUserEnabled: false
     anonymousPullEnabled: false
-    publicNetworkAccess: 'Enabled'
-    networkRuleBypassOptions: 'AzureServices'
+    azureADAuthenticationAsArmPolicyStatus: 'enabled'
+    exportPolicyStatus: 'enabled'
+    softDeletePolicyStatus: 'disabled'
+    softDeletePolicyDays: 7
+    publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
+    // networkRuleBypassOptions and networkRuleSet are Premium-only; suppress them
+    // unless the registry is Premium (private networking or scalability enabled).
+    networkRuleBypassOptions: (enablePrivateNetworking || enableScalability) ? 'AzureServices' : null
+    networkRuleSetDefaultAction: (enablePrivateNetworking || enableScalability) ? 'Deny' : 'Allow'
     roleAssignments: concat(pullRoleAssignments, pushRoleAssignments)
     managedIdentities: managedIdentities
+    privateEndpoints: enablePrivateNetworking
+      ? [
+          {
+            name: 'pep-${name}'
+            customNetworkInterfaceName: 'nic-${name}'
+            service: 'registry'
+            subnetResourceId: privateEndpointSubnetResourceId
+            privateDnsZoneGroup: {
+              privateDnsZoneGroupConfigs: [
+                { privateDnsZoneResourceId: privateDnsZoneResourceId }
+              ]
+            }
+          }
+        ]
+      : []
   }
 }
 

--- a/infra/modules/container-registry.bicep
+++ b/infra/modules/container-registry.bicep
@@ -94,10 +94,8 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.9.0' =
     softDeletePolicyStatus: 'disabled'
     softDeletePolicyDays: 7
     publicNetworkAccess: enablePrivateNetworking ? 'Disabled' : 'Enabled'
-    // networkRuleBypassOptions and networkRuleSet are Premium-only; suppress them
-    // unless the registry is Premium (private networking or scalability enabled).
-    networkRuleBypassOptions: (enablePrivateNetworking || enableScalability) ? 'AzureServices' : null
-    networkRuleSetDefaultAction: (enablePrivateNetworking || enableScalability) ? 'Deny' : 'Allow'
+    networkRuleBypassOptions: enablePrivateNetworking ? 'AzureServices' : null
+    networkRuleSetDefaultAction: enablePrivateNetworking ? 'Deny' : 'Allow'
     roleAssignments: concat(pullRoleAssignments, pushRoleAssignments)
     managedIdentities: managedIdentities
     privateEndpoints: enablePrivateNetworking

--- a/infra/modules/container-registry.bicep
+++ b/infra/modules/container-registry.bicep
@@ -36,7 +36,7 @@ param pushPrincipalIds array = []
   'Group'
   'ServicePrincipal'
 ])
-param pushPrincipalType string = 'User'
+param deployerType string = 'User'
 
 @description('Optional. Enable private networking. Forces the Premium SKU, disables public network access and creates a private endpoint for the registry.')
 param enablePrivateNetworking bool = false
@@ -74,7 +74,7 @@ var pushRoleAssignments = [
   for principalId in pushPrincipalIds: {
     principalId: principalId
     roleDefinitionIdOrName: acrPushRoleDefinitionId
-    principalType: pushPrincipalType
+    principalType: deployerType
   }
 ]
 

--- a/infra/scripts/build_and_deploy_images.ps1
+++ b/infra/scripts/build_and_deploy_images.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+    Builds the frontend and backend images remotely in ACR (az acr build - no
+    local Docker needed), pushes them to the ACR created by `azd up`, updates the
+    frontend App Service to the new image and restarts it, then recreates the
+    backend Container Instance on the new image.
+
+.DESCRIPTION
+    Run AFTER `azd up`. Configuration is read from the azd environment.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Az {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$AzArgs)
+    & az @AzArgs
+    if ($LASTEXITCODE -ne 0) { throw "az $($AzArgs -join ' ') failed with exit code $LASTEXITCODE" }
+}
+
+# Load azd environment outputs into the process environment.
+if (Get-Command azd -ErrorAction SilentlyContinue) {
+    foreach ($line in (azd env get-values 2>$null)) {
+        if ($line -match '^\s*([A-Za-z0-9_]+)="?(.*?)"?\s*$') {
+            Set-Item -Path "Env:$($Matches[1])" -Value $Matches[2]
+        }
+    }
+}
+
+$AcrName        = $env:AZURE_ENV_CONTAINER_REGISTRY_NAME
+$ResourceGroup  = $env:RESOURCE_GROUP_NAME
+$AppService     = $env:APP_SERVICE_NAME
+$ContainerGroup = $env:CONTAINER_INSTANCE_NAME
+
+$FrontendImage = 'content-gen-app'
+$BackendImage  = 'content-gen-api'
+$Tag           = 'latest'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
+
+if (-not $AcrName -or -not $ResourceGroup -or -not $AppService -or -not $ContainerGroup) {
+    throw "Missing required azd environment values (AZURE_ENV_CONTAINER_REGISTRY_NAME, RESOURCE_GROUP_NAME, APP_SERVICE_NAME, CONTAINER_INSTANCE_NAME)."
+}
+
+$AcrLoginServer = "$AcrName.azurecr.io"
+
+# ===== Build & push frontend image =====
+Write-Host "===== Building Frontend Image ($FrontendImage`:$Tag) =====" -ForegroundColor Yellow
+Invoke-Az acr build --registry $AcrName --image "$FrontendImage`:$Tag" `
+    --file (Join-Path $RepoRoot 'src\App\WebApp.Dockerfile') --platform linux (Join-Path $RepoRoot 'src\App')
+
+# ===== Build & push backend image =====
+Write-Host "===== Building Backend Image ($BackendImage`:$Tag) =====" -ForegroundColor Yellow
+Invoke-Az acr build --registry $AcrName --image "$BackendImage`:$Tag" `
+    --file (Join-Path $RepoRoot 'src\backend\ApiApp.Dockerfile') --platform linux (Join-Path $RepoRoot 'src\backend')
+
+# ===== Update frontend App Service image (managed-identity ACR pull) =====
+Write-Host "===== Updating Frontend App Service ($AppService) =====" -ForegroundColor Yellow
+$UamiRid  = az webapp identity show -g $ResourceGroup -n $AppService --query "userAssignedIdentities | keys(@) | [0]" -o tsv
+$ClientId = az identity show --ids $UamiRid --query clientId -o tsv
+
+Invoke-Az webapp config container set -g $ResourceGroup -n $AppService `
+    --container-image-name "$AcrLoginServer/$FrontendImage`:$Tag" `
+    --container-registry-url "https://$AcrLoginServer" --output none
+    --only-show-errors | Out-Null
+
+$WebappId = az webapp show -g $ResourceGroup -n $AppService --query id -o tsv
+# Invoke-Az resource update --ids "$WebappId/config/web" `
+#     --set properties.acrUseManagedIdentityCreds=true `
+#     --set properties.acrUserManagedIdentityID=$ClientId --output none
+
+Write-Host "Restarting Frontend App Service..." -ForegroundColor Yellow
+Invoke-Az webapp restart -g $ResourceGroup -n $AppService --output none
+
+# ===== Recreate backend Container Instance with the new image =====
+# ACI cannot update a container group's image in place, and a restart reuses the
+# originally deployed (hello-world) image. So we capture the existing container
+# group's configuration and recreate it pointing at the new ACR image.
+Write-Host "===== Recreating Backend Container Instance ($ContainerGroup) =====" -ForegroundColor Yellow
+
+$Aci = az container show -g $ResourceGroup -n $ContainerGroup -o json | ConvertFrom-Json
+if (-not $Aci) { throw "Could not read existing container group '$ContainerGroup'." }
+
+$AciCpu      = $Aci.containers[0].resources.requests.cpu
+$AciMemory   = $Aci.containers[0].resources.requests.memoryInGb
+$AciPort     = $Aci.containers[0].ports[0].port
+$AciOsType   = $Aci.osType
+$AciRestart  = $Aci.restartPolicy
+$AciDnsLabel = $Aci.ipAddress.dnsNameLabel
+$AciSubnetId = if ($Aci.subnetIds) { $Aci.subnetIds[0].id } else { $null }
+$AciUami     = @($Aci.identity.userAssignedIdentities.PSObject.Properties.Name)[0]
+$AciEnvVars  = $Aci.containers[0].environmentVariables | ForEach-Object { "$($_.name)=$($_.value)" }
+
+$CreateArgs = @(
+    'container', 'create',
+    '--resource-group', $ResourceGroup,
+    '--name', $ContainerGroup,
+    '--image', "$AcrLoginServer/$BackendImage`:$Tag",
+    '--cpu', $AciCpu,
+    '--memory', $AciMemory,
+    '--ports', $AciPort,
+    '--os-type', $AciOsType,
+    '--restart-policy', $AciRestart,
+    '--assign-identity', $AciUami,
+    '--acr-identity', $AciUami,
+    '--registry-login-server', $AcrLoginServer
+)
+if ($AciSubnetId) {
+    $CreateArgs += @('--subnet', $AciSubnetId)
+} else {
+    $CreateArgs += @('--ip-address', 'Public', '--dns-name-label', $AciDnsLabel)
+}
+$CreateArgs += '--environment-variables'
+$CreateArgs += $AciEnvVars
+
+Invoke-Az @CreateArgs --output none
+
+Write-Host ""
+Write-Host "===== Done =====" -ForegroundColor Green
+Write-Host "Frontend image: $AcrLoginServer/$FrontendImage`:$Tag" -ForegroundColor Cyan
+Write-Host "Backend image:  $AcrLoginServer/$BackendImage`:$Tag" -ForegroundColor Cyan

--- a/infra/scripts/build_and_deploy_images.ps1
+++ b/infra/scripts/build_and_deploy_images.ps1
@@ -64,9 +64,9 @@ Invoke-Az webapp config container set -g $ResourceGroup -n $AppService `
     --container-registry-url "https://$AcrLoginServer" --output none --only-show-errors
 
 $WebappId = az webapp show -g $ResourceGroup -n $AppService --query id -o tsv
-# Invoke-Az resource update --ids "$WebappId/config/web" `
-#     --set properties.acrUseManagedIdentityCreds=true `
-#     --set properties.acrUserManagedIdentityID=$ClientId --output none
+Invoke-Az resource update --ids "$WebappId/config/web" `
+    --set properties.acrUseManagedIdentityCreds=true `
+    --set properties.acrUserManagedIdentityID=$ClientId --output none
 
 Write-Host "Restarting Frontend App Service..." -ForegroundColor Yellow
 Invoke-Az webapp restart -g $ResourceGroup -n $AppService --output none

--- a/infra/scripts/build_and_deploy_images.ps1
+++ b/infra/scripts/build_and_deploy_images.ps1
@@ -61,8 +61,7 @@ $ClientId = az identity show --ids $UamiRid --query clientId -o tsv
 
 Invoke-Az webapp config container set -g $ResourceGroup -n $AppService `
     --container-image-name "$AcrLoginServer/$FrontendImage`:$Tag" `
-    --container-registry-url "https://$AcrLoginServer" --output none
-    --only-show-errors | Out-Null
+    --container-registry-url "https://$AcrLoginServer" --output none --only-show-errors
 
 $WebappId = az webapp show -g $ResourceGroup -n $AppService --query id -o tsv
 # Invoke-Az resource update --ids "$WebappId/config/web" `

--- a/infra/scripts/build_and_deploy_images.sh
+++ b/infra/scripts/build_and_deploy_images.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# build_and_deploy_images.sh
+# ----------------------------------------------------------------------------
+# Builds the frontend and backend images remotely in ACR (az acr build - no
+# local Docker needed), pushes them to the ACR created by `azd up`, updates the
+# frontend App Service to the new image and restarts it, then recreates the
+# backend Container Instance on the new image.
+#
+# Run AFTER `azd up`. Configuration is read from the azd environment.
+# ============================================================================
+
+# Load azd environment outputs into the shell.
+if command -v azd >/dev/null 2>&1; then
+  eval "$(azd env get-values 2>/dev/null | sed 's/^/export /')"
+fi
+
+ACR_NAME="${AZURE_ENV_CONTAINER_REGISTRY_NAME:-}"
+RESOURCE_GROUP="${RESOURCE_GROUP_NAME:-}"
+APP_SERVICE="${APP_SERVICE_NAME:-}"
+CONTAINER_GROUP="${CONTAINER_INSTANCE_NAME:-}"
+
+FRONTEND_IMAGE="content-gen-app"
+BACKEND_IMAGE="content-gen-api"
+TAG="latest"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [ -z "${ACR_NAME}" ] || [ -z "${RESOURCE_GROUP}" ] || [ -z "${APP_SERVICE}" ] || [ -z "${CONTAINER_GROUP}" ]; then
+  echo "ERROR: Missing required azd environment values (AZURE_ENV_CONTAINER_REGISTRY_NAME, RESOURCE_GROUP_NAME, APP_SERVICE_NAME, CONTAINER_INSTANCE_NAME)." >&2
+  exit 1
+fi
+
+ACR_LOGIN_SERVER="${ACR_NAME}.azurecr.io"
+
+# ===== Build & push frontend image =====
+echo "===== Building Frontend Image (${FRONTEND_IMAGE}:${TAG}) ====="
+az acr build --registry "${ACR_NAME}" --image "${FRONTEND_IMAGE}:${TAG}" \
+  --file "${REPO_ROOT}/src/App/WebApp.Dockerfile" --platform linux "${REPO_ROOT}/src/App"
+
+# ===== Build & push backend image =====
+echo "===== Building Backend Image (${BACKEND_IMAGE}:${TAG}) ====="
+az acr build --registry "${ACR_NAME}" --image "${BACKEND_IMAGE}:${TAG}" \
+  --file "${REPO_ROOT}/src/backend/ApiApp.Dockerfile" --platform linux "${REPO_ROOT}/src/backend"
+
+# ===== Update frontend App Service image (managed-identity ACR pull) =====
+echo "===== Updating Frontend App Service (${APP_SERVICE}) ====="
+UAMI_RID="$(az webapp identity show -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" \
+  --query "userAssignedIdentities | keys(@) | [0]" -o tsv)"
+CLIENT_ID="$(az identity show --ids "${UAMI_RID}" --query clientId -o tsv)"
+
+az webapp config container set -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" \
+  --container-image-name "${ACR_LOGIN_SERVER}/${FRONTEND_IMAGE}:${TAG}" \
+  --container-registry-url "https://${ACR_LOGIN_SERVER}" -o none
+
+WEBAPP_ID="$(az webapp show -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" --query id -o tsv)"
+# az resource update --ids "${WEBAPP_ID}/config/web" \
+#   --set properties.acrUseManagedIdentityCreds=true \
+#   --set properties.acrUserManagedIdentityID="${CLIENT_ID}" -o none
+
+echo "Restarting Frontend App Service..."
+az webapp restart -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" -o none
+
+# ===== Recreate backend Container Instance with the new image =====
+# ACI cannot update a container group's image in place, and a restart reuses the
+# originally deployed (hello-world) image. So we capture the existing container
+# group's configuration and recreate it pointing at the new ACR image.
+echo "===== Recreating Backend Container Instance (${CONTAINER_GROUP}) ====="
+
+ACI_CPU="$(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" --query "containers[0].resources.requests.cpu" -o tsv)"
+ACI_MEMORY="$(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" --query "containers[0].resources.requests.memoryInGb" -o tsv)"
+ACI_PORT="$(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" --query "containers[0].ports[0].port" -o tsv)"
+ACI_OS_TYPE="$(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" --query "osType" -o tsv)"
+ACI_RESTART="$(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" --query "restartPolicy" -o tsv)"
+ACI_DNS_LABEL="$(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" --query "ipAddress.dnsNameLabel" -o tsv)"
+ACI_SUBNET_ID="$(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" --query "subnetIds[0].id" -o tsv 2>/dev/null || true)"
+ACI_UAMI="$(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" --query "identity.userAssignedIdentities | keys(@) | [0]" -o tsv)"
+
+# Capture env vars as NAME=VALUE (handles values containing '=' such as the
+# Application Insights connection string, since az create splits on the first '=').
+ENV_VARS=()
+while IFS= read -r line; do
+  [ -n "${line}" ] && ENV_VARS+=("${line}")
+done < <(az container show -g "${RESOURCE_GROUP}" -n "${CONTAINER_GROUP}" \
+  --query "containers[0].environmentVariables[].join('=', [name, value])" -o tsv)
+
+CREATE_ARGS=(
+  container create
+  --resource-group "${RESOURCE_GROUP}"
+  --name "${CONTAINER_GROUP}"
+  --image "${ACR_LOGIN_SERVER}/${BACKEND_IMAGE}:${TAG}"
+  --cpu "${ACI_CPU}"
+  --memory "${ACI_MEMORY}"
+  --ports "${ACI_PORT}"
+  --os-type "${ACI_OS_TYPE}"
+  --restart-policy "${ACI_RESTART}"
+  --assign-identity "${ACI_UAMI}"
+  --acr-identity "${ACI_UAMI}"
+  --registry-login-server "${ACR_LOGIN_SERVER}"
+)
+if [ -n "${ACI_SUBNET_ID}" ]; then
+  CREATE_ARGS+=(--subnet "${ACI_SUBNET_ID}")
+else
+  CREATE_ARGS+=(--ip-address Public --dns-name-label "${ACI_DNS_LABEL}")
+fi
+CREATE_ARGS+=(--environment-variables "${ENV_VARS[@]}")
+
+az "${CREATE_ARGS[@]}" -o none
+
+echo ""
+echo "===== Done ====="
+echo "Frontend image: ${ACR_LOGIN_SERVER}/${FRONTEND_IMAGE}:${TAG}"
+echo "Backend image:  ${ACR_LOGIN_SERVER}/${BACKEND_IMAGE}:${TAG}"

--- a/infra/scripts/build_and_deploy_images.sh
+++ b/infra/scripts/build_and_deploy_images.sh
@@ -12,9 +12,15 @@ set -euo pipefail
 # Run AFTER `azd up`. Configuration is read from the azd environment.
 # ============================================================================
 
-# Load azd environment outputs into the shell.
+# Load azd environment outputs into the shell. Parse without `eval` so that any
+# command substitution embedded in a value cannot execute in this shell.
 if command -v azd >/dev/null 2>&1; then
-  eval "$(azd env get-values 2>/dev/null | sed 's/^/export /')"
+  while IFS='=' read -r _key _val; do
+    [ -z "${_key}" ] && continue
+    _val="${_val%\"}"
+    _val="${_val#\"}"
+    export "${_key}=${_val}"
+  done < <(azd env get-values 2>/dev/null)
 fi
 
 ACR_NAME="${AZURE_ENV_CONTAINER_REGISTRY_NAME:-}"
@@ -57,9 +63,9 @@ az webapp config container set -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" \
   --container-registry-url "https://${ACR_LOGIN_SERVER}" -o none --only-show-errors
 
 WEBAPP_ID="$(az webapp show -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" --query id -o tsv)"
-# az resource update --ids "${WEBAPP_ID}/config/web" \
-#   --set properties.acrUseManagedIdentityCreds=true \
-#   --set properties.acrUserManagedIdentityID="${CLIENT_ID}" -o none
+az resource update --ids "${WEBAPP_ID}/config/web" \
+  --set properties.acrUseManagedIdentityCreds=true \
+  --set properties.acrUserManagedIdentityID="${CLIENT_ID}" -o none
 
 echo "Restarting Frontend App Service..."
 az webapp restart -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" -o none

--- a/infra/scripts/build_and_deploy_images.sh
+++ b/infra/scripts/build_and_deploy_images.sh
@@ -54,7 +54,7 @@ CLIENT_ID="$(az identity show --ids "${UAMI_RID}" --query clientId -o tsv)"
 
 az webapp config container set -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" \
   --container-image-name "${ACR_LOGIN_SERVER}/${FRONTEND_IMAGE}:${TAG}" \
-  --container-registry-url "https://${ACR_LOGIN_SERVER}" -o none
+  --container-registry-url "https://${ACR_LOGIN_SERVER}" -o none --only-show-errors
 
 WEBAPP_ID="$(az webapp show -g "${RESOURCE_GROUP}" -n "${APP_SERVICE}" --query id -o tsv)"
 # az resource update --ids "${WEBAPP_ID}/config/web" \

--- a/infra/scripts/process_sample_data.ps1
+++ b/infra/scripts/process_sample_data.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+    Installs the post-deploy Python dependency and runs scripts/post_deploy.py to
+    load the sample data into the deployed application.
+
+.DESCRIPTION
+    Run AFTER build_and_deploy_images.ps1 has completed (the application images
+    must be built, pushed and running first). Configuration is read from the azd
+    environment.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot  = (Resolve-Path (Join-Path $ScriptDir '..\..')).Path
+
+# Load azd environment outputs into the process environment.
+if (Get-Command azd -ErrorAction SilentlyContinue) {
+    foreach ($line in (azd env get-values 2>$null)) {
+        if ($line -match '^\s*([A-Za-z0-9_]+)="?(.*?)"?\s*$') {
+            Set-Item -Path "Env:$($Matches[1])" -Value $Matches[2]
+        }
+    }
+}
+
+# Resolve the Python executable (python on Windows, python3 on some systems).
+$python = (Get-Command python -ErrorAction SilentlyContinue) ?? (Get-Command python3 -ErrorAction SilentlyContinue)
+if (-not $python) { throw "Python is not installed or not on PATH." }
+$python = $python.Source
+
+Write-Host "===== Installing post-deploy dependencies =====" -ForegroundColor Yellow
+& $python -m pip install -r (Join-Path $RepoRoot 'scripts\requirements-post-deploy.txt') --quiet | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "pip install failed with exit code $LASTEXITCODE" }
+
+Write-Host "===== Loading sample data =====" -ForegroundColor Yellow
+& $python (Join-Path $RepoRoot 'scripts\post_deploy.py') --skip-tests
+if ($LASTEXITCODE -ne 0) { throw "post_deploy.py failed with exit code $LASTEXITCODE" }
+
+Write-Host ""
+Write-Host "===== Done =====" -ForegroundColor Green

--- a/infra/scripts/process_sample_data.sh
+++ b/infra/scripts/process_sample_data.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# process_sample_data.sh
+# ----------------------------------------------------------------------------
+# Installs the post-deploy Python dependency and runs scripts/post_deploy.py to
+# load the sample data into the deployed application.
+#
+# Run AFTER build_and_deploy_images.sh has completed (the application images
+# must be built, pushed and running first). Configuration is read from the azd
+# environment.
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Load azd environment outputs into the shell.
+if command -v azd >/dev/null 2>&1; then
+  eval "$(azd env get-values 2>/dev/null | sed 's/^/export /')"
+fi
+
+# Resolve the Python executable (python3 preferred, fall back to python).
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON="python"
+else
+  echo "ERROR: Python is not installed or not on PATH." >&2
+  exit 1
+fi
+
+echo "===== Installing post-deploy dependencies ====="
+"${PYTHON}" -m pip install -r "${REPO_ROOT}/scripts/requirements-post-deploy.txt" --quiet
+
+echo "===== Loading sample data ====="
+"${PYTHON}" "${REPO_ROOT}/scripts/post_deploy.py" --skip-tests
+
+echo ""
+echo "===== Done ====="

--- a/infra/scripts/process_sample_data.sh
+++ b/infra/scripts/process_sample_data.sh
@@ -15,9 +15,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-# Load azd environment outputs into the shell.
+# Load azd environment outputs into the shell. Parse without `eval` so that any
+# command substitution embedded in a value cannot execute in this shell.
 if command -v azd >/dev/null 2>&1; then
-  eval "$(azd env get-values 2>/dev/null | sed 's/^/export /')"
+  while IFS='=' read -r _key _val; do
+    [ -z "${_key}" ] && continue
+    _val="${_val%\"}"
+    _val="${_val#\"}"
+    export "${_key}=${_val}"
+  done < <(azd env get-values 2>/dev/null)
 fi
 
 # Resolve the Python executable (python3 preferred, fall back to python).


### PR DESCRIPTION
## Purpose
This pull request introduces a major refactor to the Azure infrastructure deployment process, specifically around provisioning and managing the Azure Container Registry (ACR). The main changes include moving ACR provisioning into the Bicep deployment (instead of requiring a pre-existing registry), updating deployment scripts and outputs accordingly, and improving the post-provision instructions. Application images are now built and pushed to the newly provisioned ACR after the initial deployment, with placeholder images used until that step is completed.

Key changes include:

**Container Registry Provisioning and Management**
- Added a new `modules/container-registry.bicep` module to provision the Azure Container Registry as part of the deployment, including role assignments for pull and push access, private networking, and outputting relevant ACR details.
- Integrated the new ACR module into `main.bicep`, removing the need for the `acrName` and `imageTag` parameters, and updating all references to use outputs from the provisioned registry. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L138-L143) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L156-L157) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R367-R397) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1147-R1176)
- Extended private DNS zone support to include `privatelink.azurecr.io` for private ACR endpoints.

**Deployment Workflow and Scripts**
- Updated post-provision instructions in `azure.yaml` to direct users to build and push application images after deployment, and then load sample data, instead of running these steps automatically.
- Updated outputs and environment variable references to reflect the new ACR provisioning logic.

**Resource Configuration Updates**
- Changed the web app and container instance to use a public "hello-world" placeholder image initially, with configuration for managed identity-based ACR authentication, so they can be updated to use private images after they are built and pushed. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L969-R1001) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L1016-R1051)
- Updated the container instance module to accept an optional ACR login server and configure image registry credentials for managed identity authentication. [[1]](diffhunk://#diff-5613ab5fe18cb1e2d58e2f1081705f8a42df90046fe042a5c4654780f65f3c4bR37-R39) [[2]](diffhunk://#diff-5613ab5fe18cb1e2d58e2f1081705f8a42df90046fe042a5c4654780f65f3c4bL105-R117)

**Parameter and Template Cleanup**
- Removed now-unnecessary parameters (`acrName`, `imageTag`) from parameter files and main Bicep template. [[1]](diffhunk://#diff-834bc11e3cb55730076a7d70767b75f794dc9a37305f27d99926e0fd24363c13L43-L48) [[2]](diffhunk://#diff-f77c51c643b32c3e1047253afb8466b420d90485fb399eede5fb04ce6738b9b6L44-L49) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L138-L143)

These changes streamline the deployment process, improve security and automation, and make it easier to manage and update application images in a consistent way.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Golden Path Validation
- [x] I have tested the primary workflows (the "golden path") to ensure they function correctly without errors.

## Deployment Validation
- [x] I have validated the deployment process successfully and all services are running as expected with this change.